### PR TITLE
New compatibility options to fix behavior of some non RFC email clients

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -273,8 +273,10 @@ imap_before_smtp      = no
 #
 # idle_timeout          = 30
 
-# during IDLE, how often should the server send an '* OK' still
+# during IDLE, how often should the server send an '* OK Still here' still
 # here message (default: 10)
+#
+# if is set to 0 then the server will not send '* OK Still here' message
 #
 # the time between such a message is idle_timeout * idle_interval
 # seconds
@@ -286,6 +288,14 @@ imap_before_smtp      = no
 # not allowed. Use login_disabled=no to change this
 #
 # login_disabled        = yes
+
+#
+# Some clients (non RFC or incomplete implementations) need the server not to send the IDs of the messages
+# which, for some reasons, the server did not apply the requested modifications (default = yes )
+# 
+# set the switch to "no" if for some reason your email client cannot handle this kind of response from the server
+#
+# report_failed_message_updates = yes
 
 #
 # Provide a CAPABILITY to override the default

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -372,13 +372,14 @@ void imap_cb_time(void *arg)
 		GETCONFIGVALUE("idle_interval", "IMAP", interval);
 		if (strlen(interval) > 0) {
 			int i = atoi(interval);
-			if (i > 0 && i < 1000)
+			if (i >= 0 && i < 1000)
 				idle_interval = i;
 		}
 
 		ci_cork(session->ci);
-		if (! (++session->loop % idle_interval)) {
-			imap_session_printf(session, "* OK\r\n");
+		//if idle interval is 0 then no * OK is sent, still here
+		if ((idle_interval>0)&&(! (++session->loop % idle_interval))) {
+			imap_session_printf(session, "* OK Still Here\r\n");
 		}
 		dbmail_imap_session_mailbox_status(session,TRUE);
 		dbmail_imap_session_buff_flush(session);

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -368,7 +368,7 @@ void imap_cb_time(void *arg)
 	TRACE(TRACE_DEBUG,"[%p]", session);
 
 	if ( session->command_type == IMAP_COMM_IDLE  && session->command_state == IDLE ) {
-	       	// session is in a IDLE loop
+	    /* session is in a IDLE loop */
 		GETCONFIGVALUE("idle_interval", "IMAP", interval);
 		if (strlen(interval) > 0) {
 			int i = atoi(interval);
@@ -377,8 +377,8 @@ void imap_cb_time(void *arg)
 		}
 
 		ci_cork(session->ci);
-		//if idle interval is 0 then no * OK is sent, still here
-		if ((idle_interval>0)&&(! (++session->loop % idle_interval))) {
+		/* if idle interval = 0 then no "* OK Still here" is sent */
+		if ((idle_interval > 0) && (! (++session->loop % idle_interval))) {
 			imap_session_printf(session, "* OK Still Here\r\n");
 		}
 		dbmail_imap_session_mailbox_status(session,TRUE);

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -2406,16 +2406,17 @@ static void _ic_store_enter(dm_thread_data *D)
 		GString *failed_ids = g_list_join_u64(self->ids_list, ",");
 		buffer = p_string_new(self->pool, "");
 		Field_T val;
-		GETCONFIGVALUE("compatibility_report_skip_failed", "IMAP", val);
-		if (strlen(val)){
-			//if switch is yes then report, otherwise do not do anything
-			if (strcasecmp(val, "yes") == 0){
+		GETCONFIGVALUE("report_failed_message_updates", "IMAP", val);
+		if (strlen(val)) {
+			/* if switch is yes then report, otherwise do not do anything */
+			if (strcasecmp(val, "yes") == 0) {
 				p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
 				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported (switch pressent and set to 'yes') [%s]", self, self->tag);
-			}else{
+			} else {
 				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS NOT Reported (switch pressent and set to 'no') [%s]", self, self->tag);
 			}
-		}else{
+		} else {
+			/* if the user does not add the field into dbmail.conf the flag should be considererd yes (patch in order to work in non updated dbmail.conf)  */
 			p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
 			TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported [%s]", self, self->tag);
 		}

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -2407,16 +2407,11 @@ static void _ic_store_enter(dm_thread_data *D)
 		buffer = p_string_new(self->pool, "");
 		Field_T val;
 		GETCONFIGVALUE("report_failed_message_updates", "IMAP", val);
-		if (strlen(val)) {
-			/* if switch is yes then report, otherwise do not do anything */
-			if (strcasecmp(val, "yes") == 0) {
-				p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
-				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported (switch pressent and set to 'yes') [%s]", self, self->tag);
-			} else {
-				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS NOT Reported (switch pressent and set to 'no') [%s]", self, self->tag);
-			}
+		if (strlen(val) && strcasecmp(val, "no") == 0) {
+			/* if switch is no then do not report */
+			TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS NOT Reported [%s]", self, self->tag);
 		} else {
-			/* if the user does not add the field into dbmail.conf the flag should be considererd yes (patch in order to work in non updated dbmail.conf)  */
+			/* if switch is something else then no, report */
 			p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
 			TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported [%s]", self, self->tag);
 		}

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -2405,7 +2405,20 @@ static void _ic_store_enter(dm_thread_data *D)
 	if (self->ids_list) {
 		GString *failed_ids = g_list_join_u64(self->ids_list, ",");
 		buffer = p_string_new(self->pool, "");
-		p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
+		Field_T val;
+		GETCONFIGVALUE("compatibility_report_skip_failed", "IMAP", val);
+		if (strlen(val)){
+			//if switch is yes then report, otherwise do not do anything
+			if (strcasecmp(val, "yes") == 0){
+				p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
+				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported (switch pressent and set to 'yes') [%s]", self, self->tag);
+			}else{
+				TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS NOT Reported (switch pressent and set to 'no') [%s]", self, self->tag);
+			}
+		}else{
+			p_string_printf(buffer, "MODIFIED [%s]", failed_ids->str);
+			TRACE(TRACE_DEBUG,"[%p] MODIFIED IDS Reported [%s]", self, self->tag);
+		}
 		g_string_free(failed_ids, TRUE);
 		g_list_free(g_list_first(self->ids_list));
 		self->ids_list = NULL;


### PR DESCRIPTION
New compatibility options to fix behavior of some non RFC email clients (idle interval and IDS reporting)

[IMAP] section
idle interval=0: no "* OK Still Here", Analyzing logs this message sometimes is sent in more often then it should
compatibility_report_skip_failed="yes": disable reporting of change ids. some clients have trouble understating statement