### PR TITLE
support PostgreSQL application_name

### DIFF
--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -196,10 +196,15 @@ int db_connect(void)
 	int sweepInterval = 60;
 	Connection_T c;
 	GString *dsn;
-       
+	GString *uri;
+
 	if (strlen(db_params.dburi) != 0) {
-		TRACE(TRACE_DEBUG,"dburi: %s", db_params.dburi);
-		dburi = URL_new(db_params.dburi);
+		uri = g_string_new("");
+		g_string_append_printf(uri,"%s", db_params.dburi);
+		g_string_append_printf(uri, "&application-name=%s", server_conf ? server_conf->process_name : "dbmail_client");
+		TRACE(TRACE_DEBUG,"dburi: %s", uri->str);
+		dburi = URL_new(uri->str);
+		g_string_free(uri,TRUE);
 	} else {
 		dsn = g_string_new("");
 		g_string_append_printf(dsn,"%s://",db_params.driver);
@@ -237,6 +242,10 @@ int db_connect(void)
 
 		if (strlen((const char *)db_params.sock))
 			g_string_append_printf(dsn,"&unix-socket=%s", db_params.sock);
+
+		if (MATCH(db_params.driver,"postgresql")) {
+			g_string_append_printf(dsn, "&application-name=%s", server_conf ? server_conf->process_name : "dbmail_client");
+		}
 
 		dburi = URL_new(dsn->str);
 		g_string_free(dsn,TRUE);


### PR DESCRIPTION
Closes: http://www.dbmail.org/mantis/view.php?id=884

---

Uses server_conf which may be available in dm_db.c. It is therefore not so good for e.g. dbmail-util or dbmail-deliver which will all show as dbmail_client. This could be fixed with a new extern?

No API change means doesn't impact the existing tests.

I think by now no need to check for libzdb >= 2.8. Debian stable has 3.1. If needed maybe PR https://github.com/pjstevns/dbmail/pull/25 could be the solution.

Copied from https://github.com/pjstevns/dbmail/pull/39
