### PR TITLE
Fix fd leaks in clientbase

### DIFF
--- a/src/clientbase.c
+++ b/src/clientbase.c
@@ -419,7 +419,12 @@ void ci_read_cb(ClientBase_T *client)
 					client->client_state |= CLIENT_ERR;
 					PUNLOCK(client->lock);
 				}
+			} else { // connection was closed from client side
+				PLOCK(client->lock);
+				client->client_state |= CLIENT_ERR;
+				PUNLOCK(client->lock);
 			}
+
 			if (client->sock->ssl || client->rx) { // EOF on stdin is not an error
 				PLOCK(client->lock);
 				client->client_state |= CLIENT_EOF;


### PR DESCRIPTION
Set client_state CLIENT_ERR if connection was closed from client side.

This is bug fix for the problem which described [here](http://dbmail.org/mantis/view.php?id=1029)
Also works for 3.1.7 release.

Python script for test:
> REQUESTS_COUNT must be more than 'Max open files' for process 
> see here: /proc/(PID dbmail-imapd)/limits

```
#!/usr/bin/env python3
import socket
import time

HOST = WRITE_YOUR_HOST
PORT = 143
USER_LOGIN = 'testlogin'
USER_PASSWORD = 'testpwd'

IMAP_LOGIN_REQUEST = '. login {} {}\n'.format(USER_LOGIN, USER_PASSWORD).encode()

REQUESTS_COUNT = 2000

for _ in range(REQUESTS_COUNT):
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.connect((HOST, PORT))
        data = s.recv(4096)
        s.sendall(IMAP_LOGIN_REQUEST)
        # not wait for response from server
        if b"* BYE [Service unavailable.]" in data:
            print('Service unavailable')
            exit(1)
        else:
            print('.', end = '', flush = True)

print('\nTest finished successfully')
```