### PR TITLE
Fix “* OK Still here”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![Build Status](https://travis-ci.org/dbmail/dbmail.svg?branch=master)](https://travis-ci.org/dbmail/dbmail)
+
 > 
 >   (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
 >

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -378,7 +378,7 @@ void imap_cb_time(void *arg)
 
 		ci_cork(session->ci);
 		if (! (++session->loop % idle_interval)) {
-			imap_session_printf(session, "* OK\r\n");
+			imap_session_printf(session, "* OK Still here\r\n");
 		}
 		dbmail_imap_session_mailbox_status(session,TRUE);
 		dbmail_imap_session_buff_flush(session);


### PR DESCRIPTION
Some clients does not handle “* OK” but do “* OK message” (although in RFC 3501 is only optional, some clients may require it)