### PR TITLE
Fix imap returning invalid BODYSTRUCTURE as per #23

### DIFF
--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -1367,8 +1367,10 @@ static GList * imap_append_hash_as_string(GList *list, const char *type)
 	char *head = (char *)type;
 	GList *l = NULL;
 
-	if (! type)
+	if (! type) {
+		list = g_list_append_printf(list, "NIL");
 		return list;
+	}
 
 	TRACE(TRACE_DEBUG, "analyse [%s]", type);
 	while (type[i]) {


### PR DESCRIPTION
Fix imap returning invalid BODYSTRUCTURE when the source email is missing a Content-Type header as reported in #23 