### PR TITLE
optimizations SQL in some code update

### DIFF
--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -562,6 +562,8 @@ typedef struct { // map dbmail_messages
 	uint64_t uid;
 	uint64_t rfcsize;
 	uint64_t seq;
+	// physmessage_id
+	uint64_t phys_id;
 	int status;
 	char internaldate[IMAP_INTERNALDATE_LEN];
 	int flags[IMAP_NFLAGS];

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -1075,7 +1075,7 @@ int db_get_physmessage_id(uint64_t message_idnr, uint64_t * physmessage_id)
 {
 	PreparedStatement_T stmt;
 	Connection_T c;
-       	ResultSet_T r; 
+	ResultSet_T r; 
 	volatile int t = DM_SUCCESS;
 	assert(physmessage_id != NULL);
 	*physmessage_id = 0;
@@ -1090,6 +1090,7 @@ int db_get_physmessage_id(uint64_t message_idnr, uint64_t * physmessage_id)
 
 		if (db_result_next(r))
 			*physmessage_id = db_result_get_u64(r, 0);
+		//TRACE(TRACE_DEBUG,"Retrieved [%" PRIu64 "]",*physmessage_id);
 	CATCH(SQLException)
 		LOG_SQLERROR;
 		t = DM_EQUERY;

--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -780,6 +780,7 @@ static void _fetch_headers(ImapSession *self, body_fetch *bodyfetch, gboolean no
 			bodyfetch->names = g_list_next(bodyfetch->names);
 			fieldseq++;
 		}
+		fieldseq++;
 		//adding default value, useful in NOT conditions, Cosmin Cioranu
 		g_string_append_printf(fieldorder, "ELSE %d END AS seq",fieldseq);
 	}

--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -789,8 +789,10 @@ static void _fetch_headers(ImapSession *self, body_fetch *bodyfetch, gboolean no
 			"LEFT JOIN %smessages m ON h.physmessage_id=m.physmessage_id "
 			"LEFT JOIN %sheadername n ON h.headername_id=n.id "
 			"LEFT JOIN %sheadervalue v ON h.headervalue_id=v.id "
-			"WHERE m.mailbox_idnr = %" PRIu64 " "
+			"WHERE "
+			"m.mailbox_idnr = %" PRIu64 " "
 			"AND m.message_idnr %s "
+			"AND status < %d "
 			//"AND n.headername %s IN ('%s') "	//old, from the sql point of view is slow
 			"having seq %s %d "			//patch Cosmin Cioranu, removing the above conditions needs a restriction, patched added
 			"ORDER BY message_idnr, seq",
@@ -798,6 +800,7 @@ static void _fetch_headers(ImapSession *self, body_fetch *bodyfetch, gboolean no
 			DBPFX, DBPFX, DBPFX, DBPFX,
 			self->mailbox->id, p_string_str(range),
 			//not?"NOT":"", bodyfetch->hdrnames	//old 
+			MESSAGE_STATUS_DELETE,			//return information only related to valid messages
 			not?"=":"<",fieldseq			//patch Cosmin Cioranu, added the having conditions and also the 'not' handler
 		    );
 

--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -108,7 +108,7 @@ static T state_load_messages(T M, Connection_T c)
 	date2char_str("internal_date", &frag);
 	snprintf(query, DEF_QUERYSIZE-1,
 			"SELECT seen_flag, answered_flag, deleted_flag, flagged_flag, "
-			"draft_flag, recent_flag, %s, rfcsize, seq, m.message_idnr, status "
+			"draft_flag, recent_flag, %s, rfcsize, seq, m.message_idnr, status, m.physmessage_id "
 			"FROM %smessages m "
 			"LEFT JOIN %sphysmessage p ON p.id = m.physmessage_id "
 			"WHERE m.mailbox_idnr = ? AND m.status < %d "
@@ -159,6 +159,8 @@ static T state_load_messages(T M, Connection_T c)
 		result->seq = db_result_get_u64(r,IMAP_NFLAGS + 2);
 		/* status */
 		result->status = db_result_get_int(r, IMAP_NFLAGS + 4);
+		/* physmessage_id */
+		result->phys_id = db_result_get_int(r, IMAP_NFLAGS + 5);
 		g_tree_insert(msginfo, uid, result); 
 
 	}


### PR DESCRIPTION
Evaluating the way initial states are build, it can be optimized either by using pure sql or some small coding workarounds: 
- load state will include only valid messages (state=0 and state=1), old version did include all
- keywords sql was optimized in order to limit internal tree search 
- for the readability most of the queries that were related to status ware changed to include status<MESSAGE_STATUS_DELETED and not status in (MESSAGE_STATUS_NEW,MESSAGE_STATUS_SEEN) 
- optimized the way phymessage_id is retrieved from database, offloading the db
- optimized header retrieving sql in order to offload the database

Some of the related information can be found in #47 