### PR TITLE
Fix bye command

### DIFF
--- a/src/imap4.c
+++ b/src/imap4.c
@@ -450,7 +450,7 @@ static void imap_handle_retry(ImapSession *session)
 static void imap_handle_done(ImapSession *session)
 {
 	/* only do this in the main thread */
-	imap_session_printf(session, "* BYE\r\n");
+	imap_session_printf(session, "* BYE Requested\r\n");
 	imap_session_printf(session, "%s OK LOGOUT completed\r\n", session->tag);
 	imap_session_bailout(session);
 }


### PR DESCRIPTION
Fix BYE command
Some clients do not accept missing message on BYE command (e.g. Outlook 2016). Even [RFC3501 ](https://tools.ietf.org/html/rfc3501#page-67) does not require a message, given the situation it is best to provide it. 