### PR TITLE
Fix bodystructure format

### DIFF
--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -1369,7 +1369,7 @@ static GList * imap_append_hash_as_string(GList *list, const char *type)
 	
 	if (! type){
 		//in case of tye null, it should return NIL, same process is applied at the end of this function
-		TRACE(TRACE_DEBUG, "content-type is null (missing): NIL");
+		TRACE(TRACE_DEBUG, "hash_as_string: is null (missing): NIL");
 		list = g_list_append_printf(list, "NIL");
 		return list;
 	}
@@ -1400,8 +1400,8 @@ static GList * imap_append_hash_as_string(GList *list, const char *type)
 	int offset = 0;
 	int inname = 1;
 	TRACE(TRACE_DEBUG, "analyse [%s]", head);
-	while (head && maxSize>0) {
-		//hard protection, preventing going maxsize
+	while (head && maxSize>=0) {
+		//hard protection, preventing going maxsize, until the \0
 		maxSize--;
 		curr = head[offset];
 		if ((! curr) && (offset==0))
@@ -1461,13 +1461,13 @@ static GList * imap_append_hash_as_string(GList *list, const char *type)
 
 	if (l) {
 		char *s = dbmail_imap_plist_as_string(l);
-		TRACE(TRACE_DEBUG, "plist from content-type: %s", s);
+		TRACE(TRACE_DEBUG, "hash_as_string: from %s => %s", type, s);
 		list = g_list_append_printf(list, "%s", s);
 		g_free(s);
 		
 		g_list_destroy(l);
 	} else {
-		TRACE(TRACE_DEBUG, "plist from content-type: NIL");
+		TRACE(TRACE_DEBUG, "hash_as_string: from %s => NIL",type);
 		list = g_list_append_printf(list, "NIL");
 	}
 	


### PR DESCRIPTION
Fixing bodystructure format. some information got missed upon processing header.  The fixing #12  introduced the omission of last character. So we kept the fix with a minor modification.
it fixes #49 