### PR TITLE
Enhancement differential state

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -247,6 +247,14 @@ bindip                = 127.0.0.1
 admin                 = admin:secret
 
 [IMAP]
+
+# IMAP Reload strategy
+# 1 = full reload (default)
+# 2 = diff reload (in some setups it might be beneficial, due to the fact that reloading is done in diferential mode, which may result in lower db usage)
+mailbox_update_strategy = 1
+
+
+
 # You can set an alternate banner to display when connecting to the service
 # banner = imap 4r1 server (dbmail 2.3.x)
 

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -564,6 +564,10 @@ typedef struct { // map dbmail_messages
 	uint64_t seq;
 	// physmessage_id
 	uint64_t phys_id;
+        // expunge flag
+        int expunge;
+        // expunged (pushed to client), can be removed
+        int expunged;
 	int status;
 	char internaldate[IMAP_INTERNALDATE_LEN];
 	int flags[IMAP_NFLAGS];

--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -1508,13 +1508,15 @@ static void mailbox_notify_expunge(ImapSession *self, MailboxState_T N)
 	
 	if (ids) {
 		uid = (uint64_t *)ids->data;
-		msn = g_tree_lookup(MailboxState_getIds(self->mailbox->mbstate), uid);
-		if (msn && (*msn > MailboxState_getExists(M))) {
-			TRACE(TRACE_DEBUG,"exists new [%d] old: [%d]", MailboxState_getExists(N), MailboxState_getExists(M)); 
-			dbmail_imap_session_buff_printf(self, "* %d EXISTS\r\n", MailboxState_getExists(M));
+		GTree * ids=MailboxState_getIds(self->mailbox->mbstate);
+		if (ids!=NULL){
+		    msn = g_tree_lookup(ids, uid);
+		    if (msn && (*msn > MailboxState_getExists(M))) {
+			    TRACE(TRACE_DEBUG,"exists new [%d] old: [%d]", MailboxState_getExists(N), MailboxState_getExists(M)); 
+			    dbmail_imap_session_buff_printf(self, "* %d EXISTS\r\n", MailboxState_getExists(M));
+		    }
 		}
 	}
-
 	while (ids) {
 		uid = (uint64_t *)ids->data;
 		MessageInfo *messageInfo=g_tree_lookup(MailboxState_getMsginfo(N), uid);

--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -92,7 +92,7 @@ static char* split (char *str, const char *delim){
     return p + strlen(delim);       // return tail substring
 }
 
-static T state_load_messages(T M, Connection_T c)
+static T state_load_messages(T M, Connection_T c, bool coldLoad)
 {
 	unsigned nrows = 0, i = 0, j;
 	struct timeval before, after; 
@@ -104,6 +104,21 @@ static T state_load_messages(T M, Connection_T c)
 	PreparedStatement_T stmt;
 	Field_T frag;
 	INIT_QUERY;
+	char filterCondition[64];  memset(filterCondition,0,64);
+	if (coldLoad){
+	    msginfo = g_tree_new_full((GCompareDataFunc)ucmpdata, NULL,(GDestroyNotify)g_free,(GDestroyNotify)MessageInfo_free);    
+	    TRACE(TRACE_DEBUG, "SEQ New");
+	    snprintf(filterCondition,64-1,"/*SEQ New*/ AND m.status < %d ", MESSAGE_STATUS_DELETE);
+	}else{
+	    uint64_t seq=MailboxState_getSeq(M);
+	    msginfo=MailboxState_getMsginfo(M);
+	    
+	    TRACE(TRACE_DEBUG, "SEQ RENew");
+	    //MailboxState_uid_msn_new(M);
+	    /* use seq to select only changed elements, event this which are deleted*/
+	    snprintf(filterCondition,64-1,"/*SEQ ReNew*/ AND m.seq >= %" PRIu64 "-1 AND m.status <= %d ", seq, MESSAGE_STATUS_DELETE );    
+	}
+	
 	
 	date2char_str("internal_date", &frag);
 	snprintf(query, DEF_QUERYSIZE-1,
@@ -111,13 +126,13 @@ static T state_load_messages(T M, Connection_T c)
 			"draft_flag, recent_flag, %s, rfcsize, seq, m.message_idnr, status, m.physmessage_id "
 			"FROM %smessages m "
 			"LEFT JOIN %sphysmessage p ON p.id = m.physmessage_id "
-			"WHERE m.mailbox_idnr = ? AND m.status < %d "
+			"WHERE m.mailbox_idnr = ? %s "
 			"ORDER BY m.seq DESC",
 			frag,  
 			DBPFX, DBPFX, 
-			MESSAGE_STATUS_DELETE);
+			filterCondition);
 
-	msginfo = g_tree_new_full((GCompareDataFunc)ucmpdata, NULL,(GDestroyNotify)g_free,(GDestroyNotify)MessageInfo_free);
+	
 
 	stmt = db_stmt_prepare(c, query);
 	db_stmt_set_u64(stmt, 1, M->id);
@@ -127,14 +142,34 @@ static T state_load_messages(T M, Connection_T c)
 	log_query_time(query,before,after);
 	i = 0;
 	gettimeofday(&before, NULL); 
+	int shouldAdd = 0;
 	while (db_result_next(r)) {
 		i++;
 
 		id = db_result_get_u64(r, IMAP_NFLAGS + 3);
 
 		uid = g_new0(uint64_t,1); *uid = id;
-
-		result = g_new0(MessageInfo,1);
+		
+		if (coldLoad){
+		    /* new element*/
+		    result = g_new0(MessageInfo,1);
+		    shouldAdd=1;
+		    result->expunge=0;
+		    result->expunged=0;
+			//TRACE(TRACE_DEBUG, "SEQ CREATED %ld",id);
+		}else{
+		    /* soft renew, so search */
+		    result = g_tree_lookup(msginfo,  &id);     
+		    if (result==NULL){
+				/* not found so create*/
+				result = g_new0(MessageInfo,1);
+				shouldAdd=1;
+				result->expunge=0;
+				result->expunged=0;
+		    }else{
+				//TRACE(TRACE_DEBUG, "SEQ FOUND %ld",id);
+		    }
+		}
 
 		/* id */
 		result->uid = id;
@@ -161,7 +196,35 @@ static T state_load_messages(T M, Connection_T c)
 		result->status = db_result_get_int(r, IMAP_NFLAGS + 4);
 		/* physmessage_id */
 		result->phys_id = db_result_get_int(r, IMAP_NFLAGS + 5);
-		g_tree_insert(msginfo, uid, result); 
+		
+		if (result->status>=MESSAGE_STATUS_DELETE /*|| result->flags[IMAP_FLAG_DELETED]==1*/ ){
+		    /* message is delete so mark as to be expunged */
+		    result->expunge++;
+		    if (result->expunged==1){
+				if (shouldAdd==0){
+					/* remove the node if exists  from message info, should be removed, but we will not due to some references present*/
+					//g_tree_remove(msginfo, &id); 
+					continue;
+				}
+		    }else{
+				if (shouldAdd==1){
+					/* message is in state of state=2 or already deleted but not in our state */
+					g_free(result);
+					continue;
+				}
+			
+		    }
+		}
+		
+		if (shouldAdd==1){
+			//TRACE(TRACE_DEBUG, "SEQ ADDED %ld",id);
+		    /* it's new */
+		    g_tree_insert(msginfo, uid, result);  
+		}else{
+		    /* do not forget to remove unused references */
+		    //g_free(uid);
+		    //g_free(result);
+		}
 
 	}
 	gettimeofday(&after, NULL); 
@@ -178,10 +241,10 @@ static T state_load_messages(T M, Connection_T c)
 	snprintf(query, DEF_QUERYSIZE-1,
 		"SELECT k.message_idnr, group_concat(distinct keyword) FROM %skeywords k "
 		"LEFT JOIN %smessages m ON k.message_idnr=m.message_idnr "
-		"WHERE m.mailbox_idnr = ? AND m.status < %d "
+		"WHERE m.mailbox_idnr = ? %s "
 		"group by m.message_idnr",
 		DBPFX, DBPFX,
-		MESSAGE_STATUS_DELETE);
+		filterCondition);
 
 	nrows = 0;
 	stmt = db_stmt_prepare(c, query);
@@ -217,8 +280,11 @@ static T state_load_messages(T M, Connection_T c)
 	
 	gettimeofday(&after, NULL); 
 	log_query_time("Parsing Keywords ",before,after);
-	
-	MailboxState_setMsginfo(M, msginfo);
+	if (coldLoad){
+	    MailboxState_setMsginfo(M, msginfo);
+	}else{
+	    MailboxState_remap(M);
+	}
 
 	return M;
 }
@@ -253,7 +319,7 @@ T MailboxState_new(Mempool_T pool, uint64_t id)
 	TRY
 		db_begin_transaction(c); // we need read-committed isolation
 		state_load_metadata(M, c);
-		state_load_messages(M, c);
+		state_load_messages(M, c,true);
 		db_commit_transaction(c);
 	CATCH(SQLException)
 		LOG_SQLERROR;
@@ -268,6 +334,71 @@ T MailboxState_new(Mempool_T pool, uint64_t id)
 		MailboxState_free(&M);
 	}
 
+	return M;
+}
+
+/**
+ * Update only the mailbox. 
+ * @param M
+ * @return 
+ */
+
+T MailboxState_update(Mempool_T pool, T OldM)
+{
+	
+	T M; Connection_T c;
+	volatile int t = DM_SUCCESS;
+	gboolean freepool = FALSE;
+	uint64_t id;
+	if (! pool) {
+		pool = mempool_open();
+		freepool = TRUE;
+	}
+	id = OldM->id;
+	M = mempool_pop(pool, sizeof(*M));
+	M->pool = pool;
+	M->freepool = freepool;
+
+	TRACE(TRACE_DEBUG, "SEQ UPDATE");
+	if (! id) return M;
+	
+	M->id = id;
+	M->recent_queue = g_tree_new((GCompareFunc)ucmp);
+
+	M->keywords     = g_tree_new_full((GCompareDataFunc)_compare_data,NULL,g_free,NULL);
+	M->msginfo     = g_tree_new_full((GCompareDataFunc)ucmpdata, NULL,(GDestroyNotify)g_free,(GDestroyNotify)MessageInfo_free);    
+	//M->ids     = g_tree_new_full((GCompareDataFunc)_compare_data,NULL,g_free,NULL);
+	//M->msn     = g_tree_new_full((GCompareDataFunc)_compare_data,NULL,g_free,NULL);
+	
+	//g_tree_merge(M->recent, OldM->recent, IST_SUBSEARCH_OR);
+	g_tree_merge(M->keywords, OldM->keywords, IST_SUBSEARCH_OR);
+	g_tree_merge(M->msginfo, OldM->msginfo, IST_SUBSEARCH_OR);
+	//g_tree_merge(M->ids, OldM->ids, IST_SUBSEARCH_OR);
+	//g_tree_merge(M->msn, OldM->msn, IST_SUBSEARCH_OR);
+	
+	
+	MailboxState_resetSeq(OldM);
+	uint64_t seq = MailboxState_getSeq(OldM);
+			
+	c = db_con_get();
+	TRY 
+		db_begin_transaction(c); // we need read-committed isolation
+		state_load_metadata(M, c);
+		state_load_messages(M, c,false); //do a soft refresh
+		db_commit_transaction(c);
+	CATCH(SQLException)
+		LOG_SQLERROR;
+		db_rollback_transaction(c);
+		t = DM_EQUERY;
+	FINALLY
+		db_con_close(c);
+	END_TRY;
+
+	if (t == DM_EQUERY) {
+		TRACE(TRACE_ERR, "SEQ Error opening mailbox");
+		MailboxState_free(&M);
+	}
+	    
 	return M;
 }
 
@@ -374,6 +505,16 @@ uint64_t MailboxState_getSeq(T M)
 	}
  
 	return M->seq;
+}
+
+/**
+ * Reset the sequence stored at structure level
+ * @param M
+ * @return 
+ */
+void MailboxState_resetSeq(T M){
+    M->seq=NULL;
+    
 }
 
 unsigned MailboxState_getExists(T M)


### PR DESCRIPTION
DBMail creates a state of the current folder and each sequential change does reissue this changes which, in some context, can stress the backend DB. 
So, a switch in configuration was proposed to use this differential state update.