### PR TITLE
Fix building with GCC 10 / -fno-common

### DIFF
--- a/src/dm_tls.c
+++ b/src/dm_tls.c
@@ -31,7 +31,7 @@
 #define THIS_MODULE "tls"
 
 
-SSL_CTX *tls_context;
+extern SSL_CTX *tls_context;
 
 /* Create the initial SSL context structure */
 SSL_CTX *tls_init(void) {


### PR DESCRIPTION
.libs/libdbmail_la-dm_tls.o:(.bss+0x0): multiple definition of `tls_context';
.libs/libdbmail_la-server.o:(.bss+0x40): first defined here