### PR TITLE
Fix for mysql 8.x datetime default value

### DIFF
--- a/sql/mysql/2_2_5-2_3_0.mysql
+++ b/sql/mysql/2_2_5-2_3_0.mysql
@@ -26,7 +26,7 @@ CREATE TABLE `dbmail_partlists` (
 
 SET FOREIGN_KEY_CHECKS=1;
 
-ALTER TABLE dbmail_mailboxes ADD mtime DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00';
+ALTER TABLE dbmail_mailboxes ADD mtime DATETIME NOT NULL DEFAULT '1000-01-01 00:00:00';
 ALTER TABLE dbmail_mailboxes ADD KEY mtime (mtime);
 ALTER TABLE dbmail_mailboxes CHANGE name name VARCHAR(255) NOT NULL DEFAULT '';
 

--- a/sql/mysql/create_tables.mysql
+++ b/sql/mysql/create_tables.mysql
@@ -277,7 +277,7 @@ CREATE TABLE `dbmail_partlists` (
 DROP TABLE IF EXISTS `dbmail_pbsp`;
 CREATE TABLE `dbmail_pbsp` (
   `idnr` bigint(20) UNSIGNED NOT NULL auto_increment,
-  `since` datetime NOT NULL default '0000-00-00 00:00:00',
+  `since` datetime NOT NULL default '1000-01-01 00:00:00',
   `ipnumber` varchar(40) NOT NULL,
   PRIMARY KEY  (`idnr`),
   UNIQUE KEY `ipnumber_index` (`ipnumber`),
@@ -293,7 +293,7 @@ CREATE TABLE `dbmail_physmessage` (
   `id` bigint(20) UNSIGNED NOT NULL auto_increment,
   `messagesize` bigint(20) UNSIGNED NOT NULL default '0',
   `rfcsize` bigint(20) UNSIGNED NOT NULL default '0',
-  `internal_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `internal_date` datetime NOT NULL default '1000-01-01 00:00:00',
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -320,7 +320,7 @@ CREATE TABLE `dbmail_replycache` (
   `to_addr` varchar(255) NOT NULL default '',
   `from_addr` varchar(255) NOT NULL default '',
   `handle` varchar(255) NOT NULL default '',
-  `lastseen` datetime NOT NULL default '0000-00-00 00:00:00',
+  `lastseen` datetime NOT NULL default '1000-01-01 00:00:00',
   UNIQUE KEY `replycache_1` (`to_addr`,`from_addr`,`handle`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/sql/mysql/migrate_from_1.x_to_2.0_innodb.mysql
+++ b/sql/mysql/migrate_from_1.x_to_2.0_innodb.mysql
@@ -107,7 +107,7 @@ CREATE TABLE dbmail_physmessage (
 	id bigint(21) NOT NULL auto_increment,
 	messagesize bigint(21) NOT NULL default '0',
 	rfcsize bigint(21) NOT NULL default '0',
-	internal_date datetime NOT NULL default '0000-00-00 00:00:00',
+	internal_date datetime NOT NULL default '1000-01-01 00:00:00',
 	PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 # fill the dbmail_physmessage table
@@ -195,7 +195,7 @@ DROP TABLE IF EXISTS pbsp;
 DROP TABLE IF EXISTS dbmail_pbsp;
 CREATE TABLE dbmail_pbsp (
    idnr bigint(21) NOT NULL auto_increment,
-   since datetime default '0000-00-00 00:00:00' not null,
+   since datetime default '1000-01-01 00:00:00' not null,
    ipnumber varchar(40) NOT NULL,
    PRIMARY KEY (idnr),
    UNIQUE INDEX ipnumber_idx (ipnumber),

--- a/sql/mysql/migrate_from_2.0_to_2.2.mysql
+++ b/sql/mysql/migrate_from_2.0_to_2.2.mysql
@@ -167,7 +167,7 @@ CREATE TABLE dbmail_replycache (
   to_addr varchar(100) NOT NULL default '',
   from_addr varchar(100) NOT NULL default '',
   handle varchar(100) NOT NULL default '',
-  lastseen datetime NOT NULL default '0000-00-00 00:00:00',
+  lastseen datetime NOT NULL default '1000-01-01 00:00:00',
   UNIQUE KEY replycache_1 (to_addr,from_addr, handle)
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
For https://github.com/dbmail/dbmail/issues/99

Mysql 8.x changed the minimum datetime value to 1000-01-01. Thus commit changes entries using 0000-00-00 for datetime under /sql/mysql

On a side note, I noticed some defaults are epoch time (1970-01-01), and others were 0000-00-00.. not sure if there is a reason for the difference or if it even poses an issue (totally new to dbmail)