### PR TITLE
Only add application-name to postgresql dburi

### DIFF
--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -201,8 +201,8 @@ int db_connect(void)
 	if (strlen(db_params.dburi) != 0) {
 		uri = g_string_new("");
 		g_string_append_printf(uri,"%s", db_params.dburi);
-		//add application-name to the uri, only if application-name parameter was not added.
-		if ( !strstr(uri->str,"application-name") ){
+		//add application-name to the uri, only if postgresql and application-name parameter was not added.
+		if ( strncmp(uri->str,"postgresql:",11) == 0 && !strstr(uri->str,"application-name") ){
 		    //If it already has parameters then add it with "&" otherwise start adding them with "?"
 		    if ( strchr(uri->str,'?') ){
 				g_string_append_printf(uri, "&application-name=%s", server_conf ? server_conf->process_name : "dbmail_client");


### PR DESCRIPTION
I tried to run dbmail-httpd and got this log:

```
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Notice:[server] server_run(+770): starting main service loop for [HTTP]
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Debug:[db] db_connect(+213): dburi: sqlite:///tmp/dbmail.db?application-name=dbmail-httpd
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Database:[db] db_connect(+261): db at dburi: [sqlite:///tmp/dbmail.db?application-name=dbmail-httpd]
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Info:[db] db_connect(+271): database connection pool created with maximum connections of [10]
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Database:[db] db_connect(+275): run a database connection reaper thread every [60] seconds
Sep 30 16:53:44 04dcede84c4b dbmail-httpd[13330]: [0x555c221b3800] Alert:[libzdb] TabortHandler(+45): SQLException: Failed to start connection pool -- unable to set database pragmas -- near "-": syntax error
 raised in ConnectionPool_start at src/db/ConnectionPool.c:295
```

Inspection in `src/dm_db.c` led me to believe that this should only be done for PostgreSQL connections. See the 
```c
		if (MATCH(db_params.driver,"postgresql")) {
			g_string_append_printf(dsn, "&application-name=%s", server_conf ? server_conf->process_name : "dbmail_client");
		}
```
at line 251.

This PR should fix this if one uses the newer dburi directly.