### PR TITLE
Update copyright and reduce memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 >   (c) 2004-2014 NFG Net Facilities Group BV, The Netherlands, support@nfg.nl
 >
->   (c) 2000-2005 IC&S, The Netherlands
+>   (c) 1999-2005 IC&S, The Netherlands
 >
 
 What is it?

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
 # Copyright (C) 2004-2013 NFG Net Facilities Group support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
 AC_INIT([dbmail], [3.3.0], [dbmail@dbmail.org])
 AC_CONFIG_AUX_DIR(config)

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,9 @@ It was downloaded from http://www.dbmail.org
 
 Copyright (C) 1999-2004 IC & S, dbmail@ic-s.nl
 Copyright (C) 2001-2006 Aaron Stone, aaron@serendipity.cx
-Copyright (C) 2004-2006 NFG Net Facilities Group BV, support@nfg.nl
+Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
 Authors: DBmail Development Team <dbmail-dev@dbmail.org>
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,4 +1,7 @@
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/man/Makefile.in
+++ b/man/Makefile.in
@@ -15,6 +15,9 @@
 @SET_MAKE@
 
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
-# Copyright (c) 2004-2011 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -15,7 +15,9 @@
 @SET_MAKE@
 
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
-# Copyright (c) 2004-2011 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/src/auth.h
+++ b/src/auth.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/clientbase.c
+++ b/src/clientbase.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/clientbase.h
+++ b/src/clientbase.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/clientsession.c
+++ b/src/clientsession.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 2004 IC & S dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/clientsession.h
+++ b/src/clientsession.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 2004 IC & S dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -2,6 +2,8 @@
  Copyright (C) 1999-2004 IC & S, dbmail@ic-s.nl
  Copyright (C) 2001-2007 Aaron Stone, aaron@serendipity.cx
  Copyright (C) 2004-2013 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License as
@@ -186,6 +188,8 @@
 "Copyright (C) 1999-2004 IC & S, dbmail@ic-s.nl\n" \
 "Copyright (C) 2001-2007 Aaron Stone, aaron@serendipity.cx\n" \
 "Copyright (C) 2004-2013 NFG Net Facilities Group BV, support@nfg.nl\n" \
+"Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl\n" \
+"Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk\n" \
 "\n" \
 "Please see the AUTHORS and THANKS files for additional contributors.\n" \
 "\n" \

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -1,7 +1,8 @@
 /*
-
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_acl.c
+++ b/src/dm_acl.c
@@ -1,6 +1,8 @@
 /*
- Copyright (C) 2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_acl.h
+++ b/src/dm_acl.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_capa.c
+++ b/src/dm_capa.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2009-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_capa.h
+++ b/src/dm_capa.h
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2009-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_cidr.c
+++ b/src/dm_cidr.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_cidr.h
+++ b/src/dm_cidr.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_config.h
+++ b/src/dm_config.h
@@ -1,5 +1,8 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_cram.c
+++ b/src/dm_cram.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2008-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_cram.h
+++ b/src/dm_cram.h
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2008-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -1,7 +1,8 @@
-/*  */
 /*
-  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_db.h
+++ b/src/dm_db.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_debug.c
+++ b/src/dm_debug.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_debug.h
+++ b/src/dm_debug.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_digest.c
+++ b/src/dm_digest.c
@@ -1,5 +1,8 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_digest.h
+++ b/src/dm_digest.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_dsn.c
+++ b/src/dm_dsn.c
@@ -1,9 +1,10 @@
 /* Delivery User Functions
  * Aaron Stone, 9 Feb 2004 */
 /*
-  
-
  Copyright (C) 2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_dsn.h
+++ b/src/dm_dsn.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_http.c
+++ b/src/dm_http.c
@@ -1,5 +1,7 @@
 /*
- Copyright (C) 2008-2012 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (C) 2004-2013 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_http.h
+++ b/src/dm_http.h
@@ -1,6 +1,7 @@
-
 /*
- Copyright (C) 2008-2012 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (C) 2004-2013 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_iconv.c
+++ b/src/dm_iconv.c
@@ -35,6 +35,15 @@ G_LOCK_DEFINE_STATIC(mutex);
 static void dbmail_iconv_close(void)
 {
 	TRACE(TRACE_DEBUG,"closing");
+	if(ic->to_db){
+		g_mime_iconv_close(ic->to_db);
+	}
+	if(ic->from_db){
+		g_mime_iconv_close(ic->from_db);
+	}
+	if(ic->from_msg){
+		g_mime_iconv_close(ic->from_msg);
+	}
 	ic->to_db = NULL;
 	ic->from_db = NULL;
 	ic->from_msg = NULL;
@@ -89,7 +98,7 @@ void dbmail_iconv_init(void)
 /* convert not encoded field to utf8 */
 char * dbmail_iconv_str_to_utf8(const char* str_in, const char *charset)
 {
-	char * subj=NULL, *t;
+	char * subj=NULL;
 	iconv_t conv_iconv = (iconv_t)-1;
 
 	dbmail_iconv_init();
@@ -97,10 +106,8 @@ char * dbmail_iconv_str_to_utf8(const char* str_in, const char *charset)
 	if (str_in==NULL)
 		return NULL;
 
-	t = (char *)str_in;
-
 	if (g_utf8_validate((const gchar *)str_in, -1, NULL) || !g_mime_utils_text_is_8bit((unsigned char *)str_in, strlen(str_in)))
-		return g_strdup(t);
+		return g_strdup(str_in);
 
 	if (charset) {
 		if ((conv_iconv=g_mime_iconv_open("UTF-8",charset)) != (iconv_t)-1) {

--- a/src/dm_iconv.c
+++ b/src/dm_iconv.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_iconv.h
+++ b/src/dm_iconv.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_imapsession.h
+++ b/src/dm_imapsession.h
@@ -1,7 +1,7 @@
 /*
- *
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
- *
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  */
 	
 #ifndef DM_COMMANDCHANNEL_H

--- a/src/dm_list.c
+++ b/src/dm_list.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_list.h
+++ b/src/dm_list.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_mailbox.c
+++ b/src/dm_mailbox.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_mailbox.h
+++ b/src/dm_mailbox.h
@@ -1,7 +1,7 @@
 /*
- * 
- 
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_mailboxstate.h
+++ b/src/dm_mailboxstate.h
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_mempool.c
+++ b/src/dm_mempool.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_mempool.h
+++ b/src/dm_mempool.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_message.h
+++ b/src/dm_message.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -2220,6 +2220,13 @@ char * imap_get_envelope(GMimeMessage *message)
 
 	s = dbmail_imap_plist_as_string(list);
 
+	GList * element;
+	list = g_list_first(list);
+	while ((element = g_list_next(list))) {
+		g_free(element->data);
+		list = g_list_next(list);
+	}
+
 	g_list_destroy(list);
 
 	return s;

--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_misc.h
+++ b/src/dm_misc.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_quota.c
+++ b/src/dm_quota.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_quota.h
+++ b/src/dm_quota.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_request.c
+++ b/src/dm_request.c
@@ -1,5 +1,7 @@
 /*
- Copyright (C) 2008-2012 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (C) 2008-2013 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_request.h
+++ b/src/dm_request.h
@@ -1,5 +1,7 @@
 /*
- Copyright (C) 2008-2012 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (C) 2004-2013 NFG Net Facilities Group BV, support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_sievescript.c
+++ b/src/dm_sievescript.c
@@ -1,5 +1,8 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_sievescript.h
+++ b/src/dm_sievescript.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_sset.c
+++ b/src/dm_sset.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2010-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2010-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_sset.h
+++ b/src/dm_sset.h
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2010-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2010-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_string.c
+++ b/src/dm_string.c
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2010-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_string.h
+++ b/src/dm_string.h
@@ -1,6 +1,7 @@
 /*
-  
- Copyright (c) 2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_tls.c
+++ b/src/dm_tls.c
@@ -1,6 +1,8 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
-  Copyright (c) 2008 John T. Guthrie III guthrie@counterexample.org
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2008 John T. Guthrie III guthrie@counterexample.org
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_tls.h
+++ b/src/dm_tls.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/dm_user.c
+++ b/src/dm_user.c
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/dm_user.h
+++ b/src/dm_user.h
@@ -1,5 +1,7 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/export.c
+++ b/src/export.c
@@ -1,6 +1,9 @@
 /*
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
  Copyright (C) 2007 Aaron Stone aaron@serendity.cx
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1,6 +1,9 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
  Copyright (C) 2006 Aaron Stone aaron@serendipity.cx
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/imapcommands.h
+++ b/src/imapcommands.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/imapd.c
+++ b/src/imapd.c
@@ -1,7 +1,9 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
  Copyright (C) 2006 Aaron Stone aaron@serendipity.cx
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/lmtp.c
+++ b/src/lmtp.c
@@ -1,6 +1,8 @@
 /*
- Copyright (C) 2004 IC & S dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/lmtp.h
+++ b/src/lmtp.h
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/lmtpd.c
+++ b/src/lmtpd.c
@@ -1,6 +1,9 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
  Copyright (C) 2006 Aaron Stone aaron@serendipity.cx
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,10 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
-This program is free software; you can redistribute it and/or 
+ This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License 
  as published by the Free Software Foundation; either 
  version 2 of the License, or (at your option) any later 

--- a/src/maintenance.c
+++ b/src/maintenance.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -1,6 +1,8 @@
 # 
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
-# Copyright (c) 2004-2010 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -17,6 +17,8 @@
 # 
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
 # Copyright (c) 2004-2010 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/src/modules/authldap.c
+++ b/src/modules/authldap.c
@@ -1,6 +1,8 @@
 /*
  Copyright (c) 2002 Aaron Stone, aaron@serendipity.cx
  Copyright (c) 2004-2010 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/modules/authsql.c
+++ b/src/modules/authsql.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2010 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/modules/sortnull.c
+++ b/src/modules/sortnull.c
@@ -1,6 +1,7 @@
 /* 
-
  Copyright (C) 1999-2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/modules/sortsieve.c
+++ b/src/modules/sortsieve.c
@@ -1,6 +1,8 @@
 /* 
-
  Copyright (C) 1999-2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/pop3.c
+++ b/src/pop3.c
@@ -1,6 +1,8 @@
 /*
-  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
   This program is free software; you can redistribute it and/or 
   modify it under the terms of the GNU General Public License 

--- a/src/pop3d.c
+++ b/src/pop3d.c
@@ -1,7 +1,9 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
  Copyright (C) 2006 Aaron Stone aaron@serendipity.cx
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/server.c
+++ b/src/server.c
@@ -1,7 +1,8 @@
 /*
-  
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/server.h
+++ b/src/server.h
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/sievecmd.c
+++ b/src/sievecmd.c
@@ -1,5 +1,8 @@
 /*
  Copyright (C) 2003 Aaron Stone
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/timsieve.c
+++ b/src/timsieve.c
@@ -1,6 +1,8 @@
 /* 
-
  Copyright (C) 1999-2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/timsieved.c
+++ b/src/timsieved.c
@@ -1,6 +1,8 @@
 /* 
- 
-Copyright (C) 2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (C) 2004 Aaron Stone aaron at serendipity dot cx
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/src/user.c
+++ b/src/user.c
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
- Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 
  This program is free software; you can redistribute it and/or 
  modify it under the terms of the GNU General Public License 

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,5 +1,7 @@
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
-# Copyright (c) 2004-2011 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/systemd/Makefile.in
+++ b/systemd/Makefile.in
@@ -15,7 +15,9 @@
 @SET_MAKE@
 
 # Copyright (C) 1999-2004 IC & S  dbmail@ic-s.nl
-# Copyright (c) 2004-2011 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or 
 # modify it under the terms of the GNU General Public License 

--- a/test-scripts/imap_long.py
+++ b/test-scripts/imap_long.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2013 Paul J Stevens paul at nfg dot nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/test-scripts/testimap.py
+++ b/test-scripts/testimap.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2004-2008 Paul J Stevens paul at nfg dot nl
+# Copyright (C) 2004-2014 Paul J Stevens paul at nfg dot nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/test-scripts/testpop.py
+++ b/test-scripts/testpop.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 
 # Copyright (C) 2004 Paul J Stevens paul at nfg dot nl
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/test/check_dbmail.h
+++ b/test/check_dbmail.h
@@ -1,5 +1,7 @@
 /*
  *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *  Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *  Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *  licence: GPLv2
  *  see COPYING for details.

--- a/test/check_dbmail_auth.c
+++ b/test/check_dbmail_auth.c
@@ -1,6 +1,8 @@
 /*
- *  Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
- *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_capa.c
+++ b/test/check_dbmail_capa.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_common.c
+++ b/test/check_dbmail_common.c
@@ -1,5 +1,7 @@
 /*
- *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_db.c
+++ b/test/check_dbmail_db.c
@@ -1,6 +1,8 @@
 /*
- *  Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
- *  Copyright (c) 2006-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_deliver.c
+++ b/test/check_dbmail_deliver.c
@@ -1,5 +1,7 @@
 /*
- *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_dsn.c
+++ b/test/check_dbmail_dsn.c
@@ -1,7 +1,9 @@
 /*
- *  Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
- *  Copyright (c) 2006-2012 NFG Net Facilities Group BV support@nfg.nl
- *  
+ *   Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
+ *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License
  *   as published by the Free Software Foundation; either

--- a/test/check_dbmail_imapd.c
+++ b/test/check_dbmail_imapd.c
@@ -1,7 +1,9 @@
 /*
  * vim: set fileencodings=utf-8
  *
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_list.c
+++ b/test/check_dbmail_list.c
@@ -1,6 +1,8 @@
 /*
- *  Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
- *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_mailbox.c
+++ b/test/check_dbmail_mailbox.c
@@ -1,5 +1,7 @@
 /*
- *  Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_mailboxstate.c
+++ b/test/check_dbmail_mailboxstate.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_mempool.c
+++ b/test/check_dbmail_mempool.c
@@ -1,5 +1,7 @@
 /*
- *  Copyright (c) 2008-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_message.c
+++ b/test/check_dbmail_message.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2004-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_misc.c
+++ b/test/check_dbmail_misc.c
@@ -1,6 +1,8 @@
 /*
- *  Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
- *  Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (C) 2006  Aaron Stone  <aaron@serendipity.cx>
+ *   Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_server.c
+++ b/test/check_dbmail_server.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2005-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_sset.c
+++ b/test/check_dbmail_sset.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2005-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_string.c
+++ b/test/check_dbmail_string.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2005-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_user.c
+++ b/test/check_dbmail_user.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2005-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License

--- a/test/check_dbmail_util.c
+++ b/test/check_dbmail_util.c
@@ -1,5 +1,7 @@
 /*
- *   Copyright (c) 2005-2012 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2005-2013 NFG Net Facilities Group BV support@nfg.nl
+ *   Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+ *   Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
  *
  *   This program is free software; you can redistribute it and/or
  *   modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Copyright updated and normalised
Earliest copyright is consistently 1999 so the README.md has been updated to reflect this
Where headers and source differ they have been updated to match
History and start remain as is