### PR TITLE
Fix message corruption bug

### DIFF
--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1386,8 +1386,13 @@ int dbmail_message_cache_headers(const DbmailMessage *self)
 
 		header_name = g_mime_header_get_name (header);
 		// Need to remove leading and trailing spaces
-		header_raw_value = g_strstrip((char*)g_mime_header_get_raw_value (header));
+		header_raw_value = (char*)g_mime_header_get_raw_value (header);
+                size_t hlen=1+strnlen(header_raw_value,65536); // Safety first!
+                char *tmp=malloc(hlen);
+                memcpy(tmp,header_raw_value,hlen);
+                header_raw_value = g_strstrip(tmp);
 		_header_cache(header_name, header_raw_value, (gpointer)self);
+		free(tmp);
 	}
 
 	/*


### PR DESCRIPTION
The `g_strstrip` is destructive and can corrupt internal gmime message structure. This happens on my system when a message has two or more identical headers (like `Received:`), and all further message pipeline deals with a corrupted structure. This sieve sorting gets it and sends corrupted messages to users with forwards.

Maybe, there are more places where `g_strstrip` has to be warped like this.