### PR TITLE
Log and pid directories appended with dbmail

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ ilja = Ilja Booij <ilja@ic-s@nl>
 aaron = Aaron Stone <aaron@serendipity.cx>
 paul = Paul Stevens <paul@nfg.nl>
 vulture = Jonathan Feally <vulture@netvulture.com>
+alan = Alan Hicks <ahicks@p-o.co.uk>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 
 [![Build Status](https://travis-ci.org/dbmail/dbmail.svg?branch=master)](https://travis-ci.org/dbmail/dbmail)
 
-> 
->   (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
->
->   (c) 2004-2014 NFG Net Facilities Group BV, The Netherlands, support@nfg.nl
->
->   (c) 1999-2005 IC&S, The Netherlands
->
+> Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
+> Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+> Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+> Copyright (c) 2000-2006 IC&S, The Netherlands
 
 What is it?
 ===========
@@ -46,8 +43,7 @@ DBMail is now a community effort to create a fast, effecient and scalable databa
 mailingsystem. Both IC&S and NFG are fully behind opensource and the GPL. Therefore DBMail has the
 GPL licence.
 
-Paul provides commercial support for this product. For more information about this you can send an
-email to support@nfg.nl.
+Support is available by raising an issue at https://github.com/dbmail/dbmail
 
 How do i install it?
 ====================
@@ -74,13 +70,13 @@ Installation Procedure
 Dependencies
 ------------
 
-* Database: MySQL 5.0 or better, PostgreSQL 8.3+, Sqlite3, Oracle
-* Glib: (>= 2.16.0)
-* GMime: (>= 2.6.20)
+* Database: Current versions of MySQL, PostgreSQL, Sqlite3 and Oracle
+* Glib: (>= 2.16)
+* GMime: (>= 3 (3.2))
 * OpenSSL
 * libmhash
 * libzdb (http://www.tildeslash.com/libzdb/)
-* libevent: (>= 2.0.21)
+* libevent: (>= 2.1)
 * Optional: libsieve (>= 2.2.1) (https://github.com/sodabrew/libsieve)
 * Optional: jemalloc
 

--- a/THANKS
+++ b/THANKS
@@ -12,10 +12,12 @@ Many people further contributed to DBMail by reporting problems,
 suggesting various improvements and submitting code patches.
 
 Aaron Stone		aaron at serendipity dot cx
+Alan Hicks		ahicks at p-o dot co dot uk
 Alex Wheeler		awheeler at royall dot com
 Chingson Chen		chingson at msquaretech dot com
 Christian G Warden	xndbmail at xerus dot org
 Christian Haugg		haugg at gmx dot de
+Cosmin Cioranu	cosmin.cioranu at gmail dot com
 Dan Weber		dan at mirrorlynx dot com
 Ed K.		        ed at hp dot uab dot edu
 Feargal Reilly		feargal at chrysalis dot net

--- a/UPGRADING
+++ b/UPGRADING
@@ -1,16 +1,16 @@
-Upgrading from DBMail 3.0 to DBMail 3.2
+Upgrading from DBMail 3.0 to DBMail 3.3
 =======================================
 
 Dependencies
 ------------
 
-* Database: MySQL 5.0 or better, PostgreSQL 8.3+, Sqlite3, Oracle
-* Glib: (>= 2.16.0)
-* GMime: (>= 2.6.20)
+* Database: Current versions of MySQL, PostgreSQL, Sqlite3 and Oracle
+* Glib: (>= 2.16)
+* GMime: (>= 3 (3.2))
 * OpenSSL
 * libmhash
 * libzdb
-* libevent: (>= 2.0.21)
+* libevent: (>= 2.1)
 
 Schema Changes
 --------------
@@ -25,7 +25,7 @@ Upgrading from DBMail 2.2 to DBMail 3.0
 Dependencies
 ------------
 
-* Database: MySQL 5.0, PostgreSQL 8.3+, or SQLite3
+* Database: Current versions of MySQL, PostgreSQL and Sqlite3
 * Glib: (>= 2.16.0)
 * GMime: (>= 2.4.0)
 * Optional: libSieve (>= 2.2.1)

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -1,7 +1,10 @@
-
-# (c) 2000-2006 IC&S, The Netherlands 
+# Configuration file for DBMAIL
 #
-# Configuration file for DBMAIL 
+# Copyright (c) 2000-2006 IC&S, The Netherlands
+# Copyright (c) 2004-2013 NFG Net Facilities Group BV support@nfg.nl
+# Copyright (c) 2014-2019 Paul J Stevens, The Netherlands, support@nfg.nl
+# Copyright (c) 2020-2022 Alan Hicks, Persistent Objects Ltd support@p-o.co.uk
+#
 
 [DBMAIL] 
 # 

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -160,17 +160,17 @@ authlog               = no
 # 
 # logfile for stdout messages
 #
-logfile               = /var/log/dbmail.log        
+logfile               = /var/log/dbmail/dbmail.log
 
 # 
 # logfile for stderr messages
 #
-errorlog              = /var/log/dbmail.err        
+errorlog              = /var/log/dbmail/dbmail.err
 
 # 
 # directory for storing PID files
 #
-pid_directory         = /var/run
+pid_directory         = /var/run/dbmail
 
 #
 # directory for locating libraries (normally has a sane default compiled-in)


### PR DESCRIPTION
Log and PID files should by default live in their respective dbmail directories
/var/log/dbmail/ and /var/run/dbmail/
as identified by BobRam in #170