### PR TITLE
Fix issue #194 by de-tainting local_part and domain

### DIFF
--- a/contrib/exim-dbmail-configure
+++ b/contrib/exim-dbmail-configure
@@ -16,6 +16,15 @@
 # are required need to be present. Blank lines, and lines starting with #
 # are ignored.
 
+# As of Exim 4.96 it is no longer possible to rely on local_part and domain
+# in received email as they are considered tained. Both the local_part and
+# domain must be checked before they can be used and after a successful match
+# are available de-tainted in $local_part_data and $domain_data.
+# If using ldap to search for aliases in the mail attribute, a sample
+# alias lookup ALIAS_LDAP_ADDRESS_DATA may be useful. The uid is usually
+# equal to the primary local_part and any other mail attribues can be
+# considered aliases, this is used to construct the delivery email.
+
 
 ########### IMPORTANT ########## IMPORTANT ########### IMPORTANT ###########
 #                                                                          #
@@ -79,6 +88,15 @@ ALIAS_SERVER_AUTH_LOGIN = SELECT CASE Count(*) \
         FROM dbmail_users \
         WHERE userid = '${quote_pgsql:$auth1}' \
         AND passwd = '${quote_pgsql:$auth2}';
+ALIAS_USER_LOCAL_PART = SELECT SUBSTR(alias, 0, POSITION('@' IN alias)) AS local_part \
+        FROM dbmail_aliases \
+        WHERE alias='${quote_pgsql:$local_part@$domain}';
+ALIAS_LDAP_ADDRESS_DATA = ${lookup ldap{ \
+        user="uid=lookup,ou=misc,dc=example,dc=com" \
+        pass="password" \
+        ldap:///ou=users,dc=example,dc=com?uid?sub?(mail=${quote_ldap: \
+        ${local_part}@${quote_ldap:$domain}})}}@${lookup \
+        pgsql{ALIAS_VIRT_DOMAIN}}
 
 ######################################################################
 #                    LDAP SETTINGS                                   #
@@ -848,8 +866,10 @@ userforward:
 localuser:
   driver = accept
   #check_local_user
-  condition = ${lookup pgsql{ALIAS_VIRT_USER}}
+  local_parts = ${lookup pgsql{ALIAS_USER_LOCAL_PART}}
+  domains   = ${lookup pgsql{ALIAS_VIRT_DOMAIN}}
   #condition = hide ${lookup ldap{ALIAS_LDAP_VIRT_USER}}
+  #address_data = ALIAS_LDAP_ADDRESS_DATA
 # local_part_suffix = +* : -*
 # local_part_suffix_optional
   # transport = local_delivery
@@ -970,7 +990,8 @@ address_reply:
 # This transport delivers email to DBMail
 dbmail_delivery:
   driver = pipe
-  command = "/usr/local/sbin/dbmail-deliver -d ${local_part}\@$domain"
+  command = "/usr/local/sbin/dbmail-deliver -d "$local_part_data@$domain_data"
+  #command = "/usr/local/sbin/dbmail-deliver -d "$address_data"
   return_fail_output
   user = mail
 

--- a/contrib/exim-dbmail-configure
+++ b/contrib/exim-dbmail-configure
@@ -990,8 +990,8 @@ address_reply:
 # This transport delivers email to DBMail
 dbmail_delivery:
   driver = pipe
-  command = "/usr/local/sbin/dbmail-deliver -d "$local_part_data@$domain_data"
-  #command = "/usr/local/sbin/dbmail-deliver -d "$address_data"
+  command = /usr/local/sbin/dbmail-deliver -d "$local_part_data@$domain_data"
+  #command = /usr/local/sbin/dbmail-deliver -d "$address_data"
   return_fail_output
   user = mail
 

--- a/doc/README.exim
+++ b/doc/README.exim
@@ -1,42 +1,14 @@
 
 
 Using DBMail with Exim4
-by Thomas Mueller
 =======================
 
-1.	Prerequisites
-	
-	* A Exim installation
-	* A DBMail installation
+DBMail works well with Exim.
 
-2.	Generic
+Both sql and ldap authentication are supported.
 
-	LOCAL_DELIVERY=transport_dbmail
+Using ldap to search for aliases using the mail attribute is supported, though
+since exim 4.96 delivery addresses must be looked up. There is a sample dbmail
+alias that may be helpful as a starting point for your ldap search.
 
-	Every router with local mail has to use 'transport = LOCAL_DELIVERY' then.
-
-3. 	dbmail-deliver
-
-	# transport using pipe
-	transport_dbmail:  
-		driver = pipe
-		command = "/usr/local/sbin/dbmail-deliver -d $local_part@$domain"
-		return_fail_output
-		user = dbmail
-
-3. 	dbmail-lmtp
-	
-	# transport using lmtp; exim and dbmail on the same host
-	transport_dbmail:
-		driver = smtp
-		protocol = lmtp
-		hosts = localhost
-		allow_localhost
-		return_path_add
-
-	LMTP requires lmtp entries in /etc/services (they are not there in Debian!).
-
-	lmtp 24/tcp
-	lmtp 24/udp
-
-	
+Sample configuration: contrib/exim-dbmail-configure


### PR DESCRIPTION
Exim 4.93 Introduced a tainting mechanism for values read from untrusted sources.

As of 4.96 it is no longer possible to rely on local_part and domain in a received email as they are considered tainted and the option allow_insecure_tainted_data has been removed. Both the local_part and domain must be checked before they can be used and after a successful match are available in $local_part_data and $domain_data.

This update follows the spirit of checking tainted data against either sql or ldap.

With the sql authdriver it's easy to check both local_part and domain as that information is easily accessible in the dbmail_alias table.

If the ldap driver is used solely for authentication, then using the sql alias table is the recommended option.

If aliases are searched using the ldap mail attribute, then alas ldap has neither the concept of local_part, nor the ability to extract it from the mail attribute, nor the ability to return a single mail attribute equal to a searched value. Nevertheless it's possible to successfully search for the mail attribute then re-construct it using the uid and domain. As the uid is usually equal to the main local_part and any other mail attributes can be considered aliases, this is used to construct the delivery email. As this is a change from previous, it is advisable to test thoroughly.