### PR TITLE
header_cache_readonly default set to yes

### DIFF
--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1430,7 +1430,7 @@ static int _header_name_get_id(const DbmailMessage *self, const char *header, ui
 	gchar *case_header, *safe_header, *frag;
 	Connection_T c; ResultSet_T r; PreparedStatement_T s;
 	Field_T config;
-	volatile gboolean cache_readonly = false;
+	volatile gboolean cache_readonly = true;
 	volatile int t = FALSE;
 
 	// rfc822 headernames are case-insensitive
@@ -1438,8 +1438,8 @@ static int _header_name_get_id(const DbmailMessage *self, const char *header, ui
 
 	config_get_value("header_cache_readonly", "DBMAIL", config);
 	if (strlen(config)) {
-		if (SMATCH(config, "true") || SMATCH(config, "yes")) {
-			cache_readonly = true;
+		if (SMATCH(config, "false") || SMATCH(config, "no")) {
+			cache_readonly = false;
 		}
 	}
 

--- a/src/maintenance.c
+++ b/src/maintenance.c
@@ -722,12 +722,12 @@ int do_check_integrity(void)
 	/* end part 5 */
 
 	/* part 6 */
-        Field_T config;
-	gboolean cache_readonly = false;
+	Field_T config;
+	gboolean cache_readonly = true;
 	config_get_value("header_cache_readonly", "DBMAIL", config);
 	if (strlen(config)) {
-		if (SMATCH(config, "true") || SMATCH(config, "yes")) {
-			cache_readonly = true;
+		if (SMATCH(config, "false") || SMATCH(config, "no")) {
+			cache_readonly = false;
 		}
 	}
 


### PR DESCRIPTION
The default was no and has been changed to yes to reflect dbmail.conf #206 