### PR TITLE
Duplicate headers reduced to warning

### DIFF
--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -310,6 +310,7 @@
 #define AUTHLOG_FIN "closed"
 
 #define LOG_SQLERROR TRACE(TRACE_ERR,"SQLException: %s", Exception_frame.message)
+#define LOG_SQLWARNING TRACE(TRACE_WARNING,"SQLException: %s", Exception_frame.message)
 #define DISPATCH(f,a) \
 	{ \
 		GError *err = NULL; \

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1612,7 +1612,7 @@ static gboolean _header_insert(uint64_t physmessage_id, uint64_t headername_id, 
 		db_stmt_exec(s);
 		db_commit_transaction(c);
 	CATCH(SQLException)
-		LOG_SQLERROR;
+		LOG_SQLWARNING;
 		db_rollback_transaction(c);
 		t = FALSE;
 	FINALLY


### PR DESCRIPTION
Headers are duplicated for any number of reasons, when failing to add a duplicate to dbmail_header these should be reduced to a warning instead of an error.