### PR TITLE
Remove deprecated -u from dbmail-util man page

### DIFF
--- a/man/dbmail-util.txt
+++ b/man/dbmail-util.txt
@@ -9,7 +9,7 @@ datatables.
 
 SYNOPSIS
 --------
-dbmail-util [-actubpds] [-l time] [-yn] [-qvVh] [-f configFile]
+dbmail-util [-actbpds] [-l time] [-yn] [-qvVh] [-f configFile]
 
 DESCRIPTION
 -----------
@@ -40,9 +40,6 @@ OPTIONS
 
 -t::
  Test for message integrity.
-
--u::
- Null message check.
 
 -b::
  Check and rebuild the body/header/envelope cache tables.

--- a/src/maintenance.c
+++ b/src/maintenance.c
@@ -98,8 +98,6 @@ int do_showhelp(void) {
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-	"\nSpecific Tasks:\n"
-	"     --upgrade-schema        upgrade sql schema\n"
 
 	);
 


### PR DESCRIPTION
As upgrades are handled automatically, deprecated dbmail-util -u should no longer appear in the help or man page.