### PR TITLE
Update dbmail.default

### DIFF
--- a/debian/dbmail.default
+++ b/debian/dbmail.default
@@ -1,2 +1,2 @@
 LOGFILE=/var/log/dbmail.log
-UTIL_OPTS=-M -c -t -u -b -p -d -y
+UTIL_OPTS="-M -c -t -u -b -p -d -y"


### PR DESCRIPTION
Fix systemd error when starting service :
"/etc/init.d/dbmail: 2: /etc/default/dbmail: -c: not found"