### PR TITLE
make-debian.sh fails on arm64

### DIFF
--- a/make-debian.sh
+++ b/make-debian.sh
@@ -43,9 +43,17 @@ pwd
 ls
 execute '	unarchive' 'tar xvf '$LIBSIEVE_FILE
 cd ${LIBSIEVE_DIR}'/'$LIBSIEVE_NAME'/src'
-execute '	configure' './configure'
+
+# libsieve fails to ./configure on arm64 (aarch64) due to config.guess.
+if [ $(uname -m) == "aarch64" ]; then
+    execute '	configure' './configure --build=unknown-unknown-linux'
+else
+    execute '	configure' './configure'
+fi
+
 execute '	make' 'make'
 execute '	make install' 'make install'
+
 
 # already installed
 #echo "Install libzdb" >>$LOG


### PR DESCRIPTION
make-debian.sh fails to install libsieve if the CPU architecture of the server is arm64...due to config.guess: 
`configure: error: cannot guess build type; you must specify one`

A workaround is to use **./configure --build=unknown-unknown-linux** instead of ./configure.

I've added a check to see if the CPU architecture is aarch64 using **uname -m**.