### PR TITLE
Default config file added to help

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -68,12 +68,13 @@ void do_showhelp(void)
 	"\n"
         "Common options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
+	"               Default: %s\n"
 	"     -q        quietly skip interactive prompts\n"
 	"               use twice to suppress error messages\n"
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-	);
+	, configFile);
 }
 
 static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,7 @@ void do_showhelp(void) {
 
 	"\nCommon options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
+	"               Default: %s\n"
 	"     -q        quietly skip interactive prompts\n"
 	"               use twice to suppress error messages\n"
 	"     -n        show the intended action but do not perform it, no to all\n"
@@ -77,7 +78,7 @@ void do_showhelp(void) {
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-	);
+	, configFile);
 }
 
 int main(int argc, char *argv[])
@@ -200,6 +201,10 @@ int main(int argc, char *argv[])
 			 * into the mail server config and thus may lose mail. */
 			PRINTF_THIS_IS_DBMAIL;
 			return 1;
+
+		case 'h':
+			do_showhelp();
+			return 0;
 
 		default:
 			usage_error = 1;

--- a/src/maintenance.c
+++ b/src/maintenance.c
@@ -91,6 +91,7 @@ int do_showhelp(void) {
 	"     -m limit  limit migration to [limit] number of physmessages. Default 10000 per run\n"
 	"\nCommon options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
+	"               Default: %s\n"
 	"     -q        quietly skip interactive prompts\n"
 	"               use twice to suppress error messages\n"
 	"     -n        show the intended action but do not perform it, no to all\n"
@@ -98,8 +99,7 @@ int do_showhelp(void) {
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-
-	);
+	, configFile);
 
 	return 0;
 }

--- a/src/server.c
+++ b/src/server.c
@@ -868,6 +868,7 @@ void server_showhelp(const char *name, const char *greeting) {
 
         printf("\nCommon options for all DBMail daemons:\n");
 	printf("     -f file   specify an alternative config file\n");
+	printf("               Default: %s\n", configFile);
 	printf("     -p file   specify an alternative runtime pidfile\n");
 	printf("     -n        stdin/stdout mode\n");
 	printf("     -D        foreground mode\n");

--- a/src/sievecmd.c
+++ b/src/sievecmd.c
@@ -682,6 +682,7 @@ int do_showhelp(void)
 
         "\nCommon options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
+	"               Default: %s\n"
 	"     -q        quietly skip interactive prompts\n"
 	"               use twice to suppress error messages\n"
 	"     -n        show the intended action but do not perform it, no to all\n"
@@ -689,7 +690,7 @@ int do_showhelp(void)
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-	);
+	, configFile);
 
 	return 0;
 }

--- a/src/user.c
+++ b/src/user.c
@@ -94,6 +94,7 @@ int do_showhelp(void)
 	"     --disable            disable authentication for user\n"
         "\nCommon options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
+	"               Default: %s\n"
 	"     -q        quietly skip interactive prompts\n"
 	"               use twice to suppress error messages\n"
 	"     -n        show the intended action but do not perform it, no to all\n"
@@ -101,7 +102,7 @@ int do_showhelp(void)
 	"     -v        verbose details\n"
 	"     -V        show the version\n"
 	"     -h        show this help message\n"
-	);
+	, configFile);
 
 	return 0;
 }


### PR DESCRIPTION
Distributions can change the default configuration file.
Help (-h) shows the default config file location.