### PR TITLE
Fix 'incompatible pointer type' compiler error

### DIFF
--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -643,7 +643,7 @@ gboolean MailboxState_isPublic(T M)
 
 gboolean MailboxState_hasKeyword(T M, const char *keyword)
 {
-	if (g_list_find_custom(M->keywords, (gpointer)keyword, dm_strcmpdata))
+	if (g_list_find_custom(M->keywords, (gpointer)keyword, (GCompareFunc) dm_strcmpdata))
 		return TRUE;
 	return FALSE;
 }


### PR DESCRIPTION
Building DBMail 3.4.1 with gcc 14.1.1 fails with compiler error

dm_mailboxstate.c:646:64: error: passing argument 3 of ‘g_list_find_custom’ from incompatible pointer type ...                      

Building against GLib 2.80.0, though neither GLib nor DBMail has changed anything surrounding this code since forever.  Evidently gcc has gotten more strict.

The offending pointer is to function (src/dm_misc.c:) dm_strcmpdata, which does double duty as type GCompareFunc and GCompareDataFunc.  the only difference being that the latter signature has an extra argument.  The implementation of dm_strcmpdata does not use the extra argument and declares it UNUSED.

Fixed by casting to the type expected by g_list_custom; safe per the preceding remarks.