### PR TITLE
Support for sending forwarding mails using the alias is a forwarding …

### DIFF
--- a/src/authmodule.c
+++ b/src/authmodule.c
@@ -92,8 +92,10 @@ int auth_load_driver(void)
 	||  !g_module_symbol(module, "auth_get_known_users",        (gpointer)&auth->get_known_users        )
 	||  !g_module_symbol(module, "auth_get_known_aliases",      (gpointer)&auth->get_known_aliases      )
 	||  !g_module_symbol(module, "auth_getclientid",            (gpointer)&auth->getclientid            )
+	||  !g_module_symbol(module, "auth_get_override_fw_sender", (gpointer)&auth->get_override_fw_sender )
 	||  !g_module_symbol(module, "auth_getmaxmailsize",         (gpointer)&auth->getmaxmailsize         )
 	||  !g_module_symbol(module, "auth_getencryption",          (gpointer)&auth->getencryption          )
+	||  !g_module_symbol(module, "auth_check_user_ext_fw",      (gpointer)&auth->check_user_ext_fw      )
 	||  !g_module_symbol(module, "auth_check_user_ext",         (gpointer)&auth->check_user_ext         )
 	||  !g_module_symbol(module, "auth_adduser",                (gpointer)&auth->adduser                )
 	||  !g_module_symbol(module, "auth_delete_user",            (gpointer)&auth->delete_user            )
@@ -146,10 +148,14 @@ GList * auth_get_known_aliases(void)
 	{ return auth->get_known_aliases(); }
 int auth_getclientid(uint64_t user_idnr, uint64_t * client_idnr)
 	{ return auth->getclientid(user_idnr, client_idnr); }
+int auth_get_override_fw_sender(const char *username_from,const char *username_to, uint64_t * override_fw_sender)
+	{ return auth->get_override_fw_sender(username_from, username_to, override_fw_sender); }
 int auth_getmaxmailsize(uint64_t user_idnr, uint64_t * maxmail_size)
 	{ return auth->getmaxmailsize(user_idnr, maxmail_size); }
 char *auth_getencryption(uint64_t user_idnr)
 	{ return auth->getencryption(user_idnr); }
+int auth_check_user_ext_fw(const char *username, GList **userids, GList **fwds, int checks)
+	{ return auth->check_user_ext_fw(username, userids, fwds, checks); }
 int auth_check_user_ext(const char *username, GList **userids, GList **fwds, int checks)
 	{ return auth->check_user_ext(username, userids, fwds, checks); }
 int auth_adduser(const char *username, const char *password, const char *enctype,

--- a/src/authmodule.h
+++ b/src/authmodule.h
@@ -20,8 +20,10 @@ typedef struct {
 	GList * (* get_known_users)(void);
 	GList * (* get_known_aliases)(void);
 	int (* getclientid)(uint64_t user_idnr, uint64_t * client_idnr);
+	int (* get_override_fw_sender)(const char *username_from, const char *username_to, uint64_t * override_fw_sender);
 	int (* getmaxmailsize)(uint64_t user_idnr, uint64_t * maxmail_size);
 	char * (* getencryption)(uint64_t user_idnr);
+	int (* check_user_ext_fw)(const char *username, GList **userids, GList **fwds, int checks);
 	int (* check_user_ext)(const char *username, GList **userids, GList **fwds, int checks);
 	int (* adduser)(const char *username, const char *password, const char *enctype,
 			uint64_t clientid, uint64_t maxmail, uint64_t * user_idnr);

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -163,7 +163,7 @@ void config_free(void)
 /* This function also strips any... # Trailing comments. */
 /* value is not modified unless something is found. */
 static int config_get_value_once(const Field_T field_name,
-		const char * const service_name,
+		const char * service_name,
 		Field_T value)
 {
 	char *dict_value;
@@ -187,7 +187,7 @@ static int config_get_value_once(const Field_T field_name,
 }
 
 int config_get_value(const Field_T field_name,
-                     const char * const service_name,
+                     const char * service_name,
                      Field_T value)
 {
 	char *key;
@@ -248,7 +248,7 @@ config_get_value_done:
  */
 
 int config_get_value_default_int(const Field_T field_name,
-					const char * const service_name,
+					const char * service_name,
 					int default_value){
 	Field_T value;
 	int result_fetch = config_get_value(field_name, service_name, value);
@@ -262,7 +262,7 @@ int config_get_value_default_int(const Field_T field_name,
 
 
 Field_T* config_get_value_default_string(const Field_T field_name,
-					const char * const service_name,
+					const char * service_name,
 					Field_T value, Field_T default_value){
 	int result_fetch = config_get_value(field_name, service_name, value);
 
@@ -506,7 +506,7 @@ void GetDBParams(void)
 
 }
 
-void config_get_timeout(ServerConfig_T *config, const char * const service)
+void config_get_timeout(ServerConfig_T *config, const char * service)
 {
 	Field_T val;
 
@@ -533,7 +533,7 @@ void config_get_timeout(ServerConfig_T *config, const char * const service)
 }
 
 
-void config_get_logfiles(ServerConfig_T *config, const char * const service)
+void config_get_logfiles(ServerConfig_T *config, const char * service)
 {
 	Field_T val;
 

--- a/src/dm_config.h
+++ b/src/dm_config.h
@@ -66,11 +66,11 @@ int config_get_value(const Field_T name, const char *service_name,
 
 
 int config_get_value_default_int(const Field_T field_name,
-                     const char * const service_name,
+                     const char * service_name,
                      int default_value);
 
 Field_T* config_get_value_default_string(const Field_T field_name,
-                     const char * const service_name,
+                     const char * service_name,
                      Field_T value, Field_T default_value);
 					 
 /* some common used functions reading config options */
@@ -89,8 +89,8 @@ void SetTraceLevel(const char *service_name);
 
 void pidfile_create(const char *pidFile, pid_t pid);
 
-void config_get_timeout(ServerConfig_T *config, const char * const service);
-void config_get_logfiles(ServerConfig_T *config, const char * const service);
+void config_get_timeout(ServerConfig_T *config, const char *  service);
+void config_get_logfiles(ServerConfig_T *config, const char * service);
 void config_get_security_actions(ServerConfig_T *config);
 
 char * config_get_pidfile(ServerConfig_T *config, const char *name);

--- a/src/dm_db.h
+++ b/src/dm_db.h
@@ -784,6 +784,10 @@ int db_replycache_unregister(const char *to, const char *from, const char *handl
 const char * db_get_sql(sql_fragment frag);
 char * db_returning(const char *s);
 
+/**
+ * get the current sequence of the mailbox
+ */
+uint64_t db_mailbox_seq_get(uint64_t mailbox_id);
 uint64_t db_mailbox_seq_update(uint64_t mailbox_id, uint64_t message_id);
 void db_message_set_seq(uint64_t message_id, uint64_t seq);
 int db_move_message(uint64_t message_id, uint64_t mailbox_id);

--- a/src/dm_dsn.c
+++ b/src/dm_dsn.c
@@ -190,6 +190,9 @@ int dsnuser_init(Delivery_T * dsnuser)
 
 	dsnuser->userids = NULL;
 	dsnuser->forwards = NULL;
+	//the structure of the forwards, internall it stores a structure of DeliveryItem_T
+	//the structure is from,to, override_fw_sender
+	dsnuser->forwards_ext = NULL;
 
 	TRACE(TRACE_DEBUG, "dsnuser initialized");
 	return 0;
@@ -223,7 +226,15 @@ void dsnuser_free(Delivery_T * dsnuser)
 		g_list_destroy(dsnuser->forwards);
 		dsnuser->forwards = NULL;
 	}
-
+	if (dsnuser->forwards_ext) {
+		dsnuser->forwards_ext = g_list_first(dsnuser->forwards_ext);
+		while(dsnuser->forwards_ext) {
+			g_free(dsnuser->forwards_ext->data);
+			dsnuser->forwards_ext = g_list_next(dsnuser->forwards_ext);
+		}
+		g_list_destroy(dsnuser->forwards_ext);
+		dsnuser->forwards_ext = NULL;
+	}
 	if (dsnuser->address) {
 		g_free(dsnuser->address);
 		dsnuser->address = NULL;
@@ -250,15 +261,19 @@ static int address_has_alias(Delivery_T *delivery)
 
 	if (!delivery->address)
 		return 0;
-
-	alias_count = auth_check_user_ext(delivery->address, &delivery->userids, &delivery->forwards, 0);
-	TRACE(TRACE_DEBUG, "user [%s] found total of [%d] aliases", delivery->address, alias_count);
+	TRACE(TRACE_DEBUG, "address_has_alias [%s]", delivery->address);
+	alias_count = auth_check_user_ext_fw(delivery->address, &delivery->userids, &delivery->forwards_ext, 0);
+	TRACE(TRACE_DEBUG, "user [%s] found total of [%d] aliases(ext)", delivery->address, alias_count);
+	//alias_count = auth_check_user_ext(delivery->address, &delivery->userids, &delivery->forwards, 0);
+	//TRACE(TRACE_DEBUG, "user [%s] found total of [%d] aliases", delivery->address, alias_count);
 
 	if (alias_count > 0)
 		return 1;
 
 	return 0;
 }
+
+
 
 // address is in format username+mailbox@domain
 // and we want to cut out the mailbox and produce
@@ -276,7 +291,8 @@ static int address_has_alias_mailbox(Delivery_T *delivery)
 			&newaddress_len, &zapped_len) != 0)
 		return 0;
 
-	alias_count = auth_check_user_ext(newaddress, &delivery->userids, &delivery->forwards, 0);
+	//alias_count = auth_check_user_ext(newaddress, &delivery->userids, &delivery->forwards, 0);
+	alias_count = auth_check_user_ext_fw(newaddress, &delivery->userids, &delivery->forwards_ext, 0);
 	TRACE(TRACE_DEBUG, "user [%s] found total of [%d] aliases", newaddress, alias_count);
 
 	g_free(newaddress);
@@ -362,8 +378,8 @@ static int address_is_domain_catchall(Delivery_T *delivery)
 		TRACE(TRACE_DEBUG, "domain [%s] checking for domain forwards", my_domain);
         
 		/* Checking for domain aliases */
-		domain_count = auth_check_user_ext(my_domain, &delivery->userids, &delivery->forwards, 0);
-        
+		//domain_count = auth_check_user_ext(my_domain, &delivery->userids, &delivery->forwards, 0);
+		domain_count = auth_check_user_ext_fw(my_domain, &delivery->userids, &delivery->forwards_ext, 0);
 		if (domain_count > 0) {
 			/* This is the way to succeed out. */
 			break;
@@ -428,7 +444,8 @@ static int address_is_userpart_catchall(Delivery_T *delivery)
 	TRACE(TRACE_DEBUG, "userpart [%s] checking for userpart forwards", userpart);
 
 	/* Checking for userpart aliases */
-	userpart_count = auth_check_user_ext(userpart, &delivery->userids, &delivery->forwards, 0);
+	//userpart_count = auth_check_user_ext(userpart, &delivery->userids, &delivery->forwards, 0);
+	userpart_count = auth_check_user_ext_fw(userpart, &delivery->userids, &delivery->forwards_ext, 0);
 	TRACE(TRACE_DEBUG, "userpart [%s] found total of [%d] aliases", userpart, userpart_count);
 
 	g_free(userpart);

--- a/src/dm_dsn.h
+++ b/src/dm_dsn.h
@@ -39,6 +39,13 @@ typedef struct {
 	int detail;
 } delivery_status_t;
 
+//structure of the forward_ext
+typedef struct {
+	char *from;
+	char *to;
+	uint64_t override_fw_sender;
+} DeliveryItem_T;
+
 typedef struct {
 	uint64_t useridnr;		/* Specific user id recipient (from outside). */
 	char *address;	/* Envelope recipient (from outside). */
@@ -46,8 +53,10 @@ typedef struct {
 	mailbox_source source; /* Who specified the mailbox (e.g. trusted or untrusted source)? */
 	GList *userids;	/* List of uint64_t* -- internal useridnr's to deliver to (internal). */
 	GList *forwards;	/* List of char* -- external addresses to forward to (internal). */
+	GList *forwards_ext; /* Extended list of forwards of DeliveryItem_T*/
 	delivery_status_t dsn;	/* Return status of this "delivery basket" (to outside). */
 } Delivery_T;
+
 
 /**
  * \brief Turn a numerical delivery status
@@ -74,6 +83,12 @@ int dsn_tostring(delivery_status_t dsn, const char ** const class,
 void set_dsn(delivery_status_t *dsn,
 		int class, int subject, int detail);
 
+/**
+ * \brief Sets override forward sender flag on the dsn delivery_status_t
+ *        inside of a delivery Delivery_T.
+ * \param delivery is a pointer to a Delivery_T struct.
+ */
+void set_override_fw_sender(Delivery_T *delivery);
 /**
  * \brief Initialize a dsnuser structure and its lists.
  * \param dsnuser Pointer to a dsnuser structure in need of initialization.

--- a/src/dm_message.h
+++ b/src/dm_message.h
@@ -87,12 +87,14 @@ size_t dbmail_message_get_size(const DbmailMessage *self, gboolean crlf);
 GList * dbmail_message_get_header_addresses(DbmailMessage *message, const char *field);
 
 
+
 /*
  * manipulate the actual message content
  */
 
 void dbmail_message_set_header(DbmailMessage *self, const char *header, const char *value);
 const gchar * dbmail_message_get_header(const DbmailMessage *self, const char *header);
+const gchar * dbmail_message_get_headers(const DbmailMessage *self);
 
 /* Get all instances of a header. */
 GList * dbmail_message_get_header_repeated(const DbmailMessage *self, const char *header);

--- a/src/lmtp.c
+++ b/src/lmtp.c
@@ -500,8 +500,9 @@ int lmtp(ClientSession_T * session)
 		msg = dbmail_message_new(NULL);
 		dbmail_message_init_with_string(msg, p_string_str(session->rbuff));
 		if (p_list_data(session->from))
-			dbmail_message_set_header(msg, "Return-Path", 
-					(char *)p_string_str(p_list_data(session->from)));
+			dbmail_message_set_header(msg, "Return-Path", (char *)p_string_str(p_list_data(session->from)));
+		//todo: add date in case the message does not have one.
+
 		p_string_truncate(session->rbuff,0);
 
 		if (insert_messages(msg, session->rcpt) == -1) {

--- a/src/maintenance.c
+++ b/src/maintenance.c
@@ -53,6 +53,7 @@ static int do_move_old(int days, char * mbinbox_name, char * mbtrash_name);
 static int do_erase_old(int days, char * mbtrash_name);
 static int do_check_integrity(void);
 static int do_purge_deleted(void);
+static int do_enable_forward(void);
 static int do_set_deleted(void);
 static int do_dangling_aliases(void);
 static int do_header_cache(void);
@@ -88,6 +89,7 @@ int do_showhelp(void) {
 	"     --inbox name  Inbox folder to move from, used in conjunction with --move\n"
 	"     --trash name  Trash folder to move to, used in conjunction with --move\n"
 	"     -m limit  limit migration to [limit] number of physmessages. Default 10000 per run\n"
+	"     --enable-forward-control make the necessary changes to support control of forwards (has not effect on authldap module\n"
 	"\nCommon options for all DBMail utilities:\n"
 	"     -f file   specify an alternative config file\n"
 	"               Default: %s\n"
@@ -108,7 +110,7 @@ int main(int argc, char *argv[])
 	int check_integrity = 0;
 	int check_iplog = 0, check_replycache = 0;
 	char *timespec_iplog = NULL, *timespec_replycache = NULL;
-	int vacuum_db = 0, purge_deleted = 0, set_deleted = 0, dangling_aliases = 0, rehash = 0, move_old = 0, erase_old = 0;
+	int vacuum_db = 0, purge_deleted = 0, set_deleted = 0, dangling_aliases = 0, rehash = 0, move_old = 0, erase_old = 0, enable_forward=0;
 	int show_help = 0;
 	int do_nothing = 1;
 	int is_header = 0;
@@ -120,6 +122,7 @@ int main(int argc, char *argv[])
 		{ "trash", 1, 0, 0 },
 		{ "inbox", 1, 0, 0 },
 		{ "upgrade", 0, 0, 0 },
+		{ "enable-forward-control",0, 0, 0},
 		{ 0, 0, 0, 0 }
 	};
 	int opt_index = 0;
@@ -163,7 +166,8 @@ int main(int argc, char *argv[])
 			if (strcmp(long_options[opt_index].name,"inbox")==0) {
 				mbinbox_name = optarg;
 			}
-			
+			if (strcmp(long_options[opt_index].name,"enable-forward-control")==0)
+				enable_forward=1;
 			break;
 		case 'a':
 			/* This list should be kept up to date. */
@@ -325,6 +329,7 @@ int main(int argc, char *argv[])
 	if (check_replycache) do_check_replycache(timespec_replycache);
 	if (vacuum_db) do_vacuum_db();
 	if (rehash) do_rehash();
+	if (enable_forward) do_enable_forward();
 	if (migrate) do_migrate(migrate_limit);
 
 	if (!has_errors && !serious_errors) {
@@ -452,6 +457,7 @@ static int db_deleted_purge(void)
 	return db_update("DELETE FROM %smessages WHERE status=%d", DBPFX, MESSAGE_STATUS_PURGE);
 }
 
+
 static int db_deleted_count(uint64_t * rows)
 {
 	Connection_T c; ResultSet_T r; volatile int t = FALSE;
@@ -473,6 +479,12 @@ static int db_deleted_count(uint64_t * rows)
 	return t;
 }
 
+int do_enable_forward(void){
+	qprintf("\nChanging schema\n");
+	db_update("alter table %saliases add override_fw_sender smallint null default '0' ", DBPFX);
+	qprintf("\nDone\n");
+	return 0;
+}
 
 int do_purge_deleted(void)
 {

--- a/src/modules/authldap.c
+++ b/src/modules/authldap.c
@@ -1,3 +1,4 @@
+
 /*
  Copyright (c) 2002 Aaron Stone, aaron@serendipity.cx
  Copyright (c) 2004-2010 NFG Net Facilities Group BV support@nfg.nl
@@ -762,7 +763,19 @@ int auth_getclientid(uint64_t user_idnr, uint64_t * client_idnr)
 
 	return TRUE;
 }
-
+/**
+ *  \brief this method is only o stub in order to compabilize th extended forwarding scheme
+ *   future ideas: one idea is to implement it via aliases, to ldap gives you the information and here you can decide
+ *   To be used in conjunction with auth_check_user_ext_fw
+ */
+int auth_get_override_fw_sender(const char *username_from,const char *username_to, uint64_t * override_fw_sender)
+{
+	assert(override_fw_sender != NULL);
+	//on LDAP is always 0, this feature is not implemented
+	*override_fw_sender = 0;
+	TRACE(TRACE_DEBUG, "found override_fw_sender [%" PRIu64 "]", *override_fw_sender);
+	return TRUE;
+}
 
 int auth_getmaxmailsize(uint64_t user_idnr, uint64_t * maxmail_size)
 {
@@ -858,6 +871,30 @@ GList * auth_get_known_aliases(void)
 	return aliases;
 }
 
+/**
+ * auth_check_user_ext_fw
+ * compatibilization, "override fw_sender" field in aliases table does not have any effect on ldap connector
+ * So this method is present here in order to create a data structure that can be used in the future.
+ */
+int auth_check_user_ext_fw(const char *address, GList **userids, GList **fwds, int checks){
+	GList *fwds_local = NULL;
+	int occurences=auth_check_user_ext(address, userids, &fwds_local, checks);
+	while(fwds_local){
+		char *deliver_to = (char *)fwds_local->data;
+		TRACE(TRACE_DEBUG, "checking user %s to %s", address, deliver_to);
+
+		DeliveryItem_T *item = g_new0(DeliveryItem_T,1);
+		item->from = NULL;
+		item->to = g_strdup(deliver_to);
+		item->override_fw_sender = 0;
+		*(GList **)fwds = g_list_prepend(*(GList **)fwds, item);
+		if (! g_list_next(fwds_local)) break;
+			fwds_local = g_list_next(fwds_local);
+	}
+	g_list_destroy(fwds_local);
+	return occurences;
+}
+
 /*
  * auth_check_user_ext()
  * 
@@ -866,7 +903,6 @@ GList * auth_get_known_aliases(void)
  * 
  * returns the number of occurences. 
  */
-
 
 	
 int auth_check_user_ext(const char *address, GList **userids, GList **fwds, int checks)


### PR DESCRIPTION
…emails to external users. dbmail is able to forward emails to external recipients, however when the external sender is outside your domain (or area of control) forwarding emails to external recipients can break spf (and dkim in some cases), to this update is able to set that for forwarding address should be used the internal recipient that have received the message. is working only for authsql module, for the authldap this functionality is not available

Support for adding the structure into aliases table to support extended forwarding. fix - issue with illegal free
fix - in some cases sequence is not increased when flags are set/reset. fix - various code writing warnings.