### PR TITLE
text/plain header fix refactored

### DIFF
--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -836,19 +836,14 @@ DbmailMessage * dbmail_message_init_with_string(DbmailMessage *self, const char 
 			self->internal_date,
 			self->internal_date_gmtoff);
 
-		const char *fixheader = "MIME-Version: 1.0\r\nContent-Type: text/plain\r\n\r\n";
-		char *fixdata = NULL;
-		memset(fixdata, 0, sizeof(strlen(fixheader) + buflen + 1));
-		//malloc(sizeof(char)*(strlen(fixheader)+buflen+1));
-
-		*fixdata = '\0';
-		strcat(fixdata, fixheader);
-		strcat(fixdata, str);
+		GString *fixdata = NULL;
+		fixdata = g_string_new("MIME-Version: 1.0\r\nContent-Type: text/plain\r\n\r\n");
+		g_string_append(fixdata, str);
 
 		// Re-create the message part
 		g_object_unref(self->stream);
 		self->stream = g_mime_stream_mem_new();
-		g_mime_stream_write(self->stream, fixdata, strlen(fixheader) + buflen + 1);
+		g_mime_stream_write(self->stream, fixdata->str, fixdata->len);
 		g_mime_stream_reset(self->stream);
 
 		parser = g_mime_parser_new_with_stream(self->stream);


### PR DESCRIPTION
Fixes memset error
Uses GString instead of const char
Tested with random test and allows inserting bad data.
text/plain header fix will need to be removed to avoid accepting bad data.