### PR TITLE
Fix for sig11 null reference

### DIFF
--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -3476,6 +3476,9 @@ int db_set_msgflag(uint64_t msg_idnr, int *flags, GList *keywords, int action_ty
 	volatile int seen = 0, count = 0;
 	INIT_QUERY;
 
+	if (! msginfo)
+		return count;
+
 	memset(query,0,DEF_QUERYSIZE);
 	/*
 	* gather the curent seq of the mailbox in keeps it in sync with the message sequence 


### PR DESCRIPTION
In imapcommands.c(1733) db_set_msgflag is called with msginfo=NULL
If msginfo is not set it returns 0.