### PR TITLE
Rework Error log config

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -86,8 +86,13 @@ sendmail              = /usr/sbin/sendmail
 #
 
 #
-# Logging via stderr/log file and syslog
+# Logging via stderr/log file and syslog using one of the following:
+# emergency, alert, critical, error, warning, notice, info, debug, database, nothing
 #
+file_logging_levels       = notice
+syslog_logging_levels     = warning
+#
+# If you need a specific logging level, numeric values are available:
 # Logging is broken up into 8 logging levels and each level can be
 # individually turned on or off.
 # The Stderr/log file logs all entries to stderr or the log file.
@@ -110,9 +115,6 @@ sendmail              = /usr/sbin/sendmail
 #            31 = Emergency + Alert + Critical + Error + Warning
 #           511 = Everything
 #
-file_logging_levels       = 31
-#
-syslog_logging_levels     = 15
 
 #
 # Generate a log entry for database queries for the log level at number of

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -292,7 +292,27 @@ void SetTraceLevel(const char *service_name)
 	config_get_value("syslog_logging_levels", service_name, syslog_logging_levels);
 	config_get_value("file_logging_levels", service_name, file_logging_levels);
 
-	if (strlen(syslog_logging_levels)) {
+	if (strcmp(syslog_logging_levels, "database") == 0) {
+		trace_syslog_int = 511;
+	} else if (strcmp(syslog_logging_levels, "debug") == 0) {
+		trace_syslog_int = 255;
+	} else if (strcmp(syslog_logging_levels, "info") == 0) {
+		trace_syslog_int = 127;
+	} else if (strcmp(syslog_logging_levels, "notice") == 0) {
+		trace_syslog_int = 63;
+	} else if (strcmp(syslog_logging_levels, "warning") == 0) {
+		trace_syslog_int = 31;
+	} else if (strcmp(syslog_logging_levels, "error") == 0) {
+		trace_syslog_int = 15;
+	} else if (strcmp(syslog_logging_levels, "critical") == 0) {
+		trace_syslog_int = 7;
+	} else if (strcmp(syslog_logging_levels, "alert") == 0) {
+		trace_syslog_int = 3;
+	} else if (strcmp(syslog_logging_levels, "emergency") == 0) {
+		trace_syslog_int = 1;
+	} else if (strcmp(syslog_logging_levels, "nothing") == 0) {
+		trace_syslog_int = 0;
+	} else if (strlen(syslog_logging_levels)) {
 		trace_syslog_int = atoi(syslog_logging_levels);
 	} else {
 		config_get_value("trace_syslog", service_name, trace_syslog);
@@ -328,7 +348,27 @@ void SetTraceLevel(const char *service_name)
 		}
 	}
 
-	if (strlen(file_logging_levels)) {
+	if (strcmp(file_logging_levels, "database") == 0) {
+		trace_stderr_int = 511;
+	} else if (strcmp(file_logging_levels, "debug") == 0) {
+		trace_stderr_int = 255;
+	} else if (strcmp(file_logging_levels, "info") == 0) {
+		trace_stderr_int = 127;
+	} else if (strcmp(file_logging_levels, "notice") == 0) {
+		trace_stderr_int = 63;
+	} else if (strcmp(file_logging_levels, "warning") == 0) {
+		trace_stderr_int = 31;
+	} else if (strcmp(file_logging_levels, "error") == 0) {
+		trace_stderr_int = 15;
+	} else if (strcmp(file_logging_levels, "critical") == 0) {
+		trace_stderr_int = 7;
+	} else if (strcmp(file_logging_levels, "alert") == 0) {
+		trace_stderr_int = 3;
+	} else if (strcmp(file_logging_levels, "emergency") == 0) {
+		trace_stderr_int = 1;
+	} else if (strcmp(file_logging_levels, "nothing") == 0) {
+		trace_stderr_int = 0;
+	} else if (strlen(file_logging_levels)) {
 		trace_stderr_int = atoi(file_logging_levels);
 	} else {
 		config_get_value("trace_stderr", service_name, trace_stderr);

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -2428,6 +2428,8 @@ int send_smtpmail(DbmailMessage *message,
 	}
 	TRACE(TRACE_DEBUG, "Using libcurl for smtp");
 
+	// This must be the synchronous libcurl easy interface
+	// to ensure atomic delivery or non delivery.
 	curl = curl_easy_init();
 	if(curl) {
 		res = curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);


### PR DESCRIPTION
Setting numeric file_logging_levels and syslog_logging_levels is complex.
This update allows normal words such as debug, warning and info

