### PR TITLE
Allow dbmail to accept invalid messages

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -59,6 +59,12 @@ encoding             = utf8
 # i.e. iso8859-1, utf8
 default_msg_encoding = utf8
 
+#
+# Only valid emails are accepted
+# set allow_invalid_messages to yes to add a mime header
+# allowing dbmail to store invalid messages
+allow_invalid_messages = no
+
 # 
 # Postmaster's email address for use in bounce messages.
 #

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -818,6 +818,7 @@ DbmailMessage * dbmail_message_init_with_string(DbmailMessage *self, const char 
 #define FROMLINE 80
 	char from[FROMLINE];
 	size_t buflen = strlen(str);
+	Field_T allow_invalid_messages = "no";
 
 	assert(self->content == NULL);
 
@@ -864,7 +865,8 @@ DbmailMessage * dbmail_message_init_with_string(DbmailMessage *self, const char 
 			self->content = content;
 		}
 	}
-	if (!content) {
+	config_get_value("allow_invalid_messages", "DBMAIL", allow_invalid_messages);
+	if (!content && strcmp(allow_invalid_messages, "yes") == 0) {
 		/* MIME part is invalid so add a simple text/plain mime header */
 		TRACE(TRACE_INFO, "Messsage parse part failed, converting to text/plain [%ld] offset [%d]",
 			self->internal_date,


### PR DESCRIPTION
There are rare occasions, for example upgrading an old 2.2 version where dbmail should process and accept invalid emails. Setting allow_invalid_messages = yes will add a mime header allowing dbmail to store an invalid message.