### PR TITLE
db_set_msgflag sets flags but shouldn't set seq fixes #314

### DIFF
--- a/src/dm_db.h
+++ b/src/dm_db.h
@@ -791,10 +791,6 @@ int db_replycache_unregister(const char *to, const char *from, const char *handl
 const char * db_get_sql(sql_fragment frag);
 char * db_returning(const char *s);
 
-/**
- * get the current sequence of the mailbox
- */
-uint64_t db_mailbox_seq_get(uint64_t mailbox_id);
 uint64_t db_mailbox_seq_update(uint64_t mailbox_id, uint64_t message_id);
 void db_message_set_seq(uint64_t message_id, uint64_t seq);
 int db_move_message(uint64_t message_id, uint64_t mailbox_id);


### PR DESCRIPTION
If a sequence is supplied to db_set_msgflag() it should only be used as a filter.
This patch restores the sequence filter and removes setting it.
Redundant db_mailbox_seq_get removed