### PR TITLE
Complete upgrade to gmime3

### DIFF
--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -68,6 +68,7 @@ typedef enum {
 } Driver_T;
 
 typedef enum {
+	DM_OVERQUOTA 	= -2, // over quota
 	DM_EQUERY 	= -1,
 	DM_SUCCESS 	= 0,
 	DM_EGENERAL 	= 1

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -21,8 +21,10 @@
 */
 
 /**
- * \file db.c
- * 
+ * RFC 9051
+ * Internet Message Access Protocol (IMAP) - Version 4rev2
+ * RFC 3501
+ * Internet Message Access Protocol (IMAP) - Version 4rev1
  */
 
 #include "dbmail.h"
@@ -99,6 +101,8 @@ struct mailbox_match * mailbox_match_new(const char *mailbox)
 
 		/**
 		 * RFC 3501 [Page 19]
+		 * RFC 9051 4.3.1
+		 * A.1. Mailbox International Naming Convention for Compatibility with IMAP4rev1
 		 *
 		 * "&" is used to shift to modified BASE64 and "-" to shift back to
 		 * US-ASCII.

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -3169,7 +3169,7 @@ int db_copymsg(uint64_t msg_idnr, uint64_t mailbox_to, uint64_t user_idnr,
 
 	if (! valid) {
 		TRACE(TRACE_INFO, "user [%" PRIu64 "] would exceed quotum", user_idnr);
-		return -2;
+		return DM_OVERQUOTA;
 	}
 
 	/* Copy the message table entry of the message. */

--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -1044,7 +1044,7 @@ static void db_getmailbox_count(T M, Connection_T c)
 	M->recent = result[2];
  
 	TRACE(TRACE_DEBUG, "exists [%d] unseen [%d] recent [%d]", M->exists, M->unseen, M->recent);
-	/* now determine the next message UID 
+	/* now determine the next message UID
 	 * NOTE:
 	 * - expunged messages are selected as well in order to be able to restore them 
 	 * - the next uit MUST NOT change unless messages are added to THIS mailbox

--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -1493,176 +1493,163 @@ char *dbmail_imap_astring_as_string(const char *s)
 	g_free(t);
 
 	return r;
-
 }
+
 /* structure and envelope tools */
-static void _structure_part_handle_part(GMimeObject *part, gpointer data, gboolean extension);
-static void _structure_part_text(GMimeObject *part, gpointer data, gboolean extension);
-static void _structure_part_message(GMimeObject *part, gpointer data, gboolean extension);
-static void _structure_part_multipart(GMimeObject *part, gpointer data, gboolean extension);
+static GList * _structure_part_handle_part(GMimeObject *part, GList *alist, gboolean extension);
+static GList * _structure_part_text(GMimeObject *part, GList *structure, gboolean extension);
+static GList * _structure_part_message(GMimeObject *part, GList *structure, gboolean extension);
+static GList * _structure_part_multipart(GMimeObject *part, GList *structure, gboolean extension);
+/* Get a header and any properties
+ * from a mime part then add as strings to the structure list
+ */
+static GList * imap_append_header_as_string(GList *structure, GMimeObject *mime_part, const char *header);
 
-
-static GList * imap_append_hash_as_string(GList *list, const char *type)
+/* Get a header and any properties
+ * from a mime part then add them as strings to the structure list
+ */
+static GList * imap_append_header_as_string(GList *structure, GMimeObject *mime_part, const char *header)
 {
-	size_t i = 0;
-	char curr = 0;
-	char name[512];
-	char value[1024];
-	char *head = (char *)type;
+	GMimeContentType *gm_type;
+	GMimeParam * gm_param;
+	GMimeParamList * gm_param_list = NULL;
+	GMimeParamEncodingMethod gm_param_encoding;
+
 	GList *l = NULL;
-	
-	if (! type){
-		//in case of tye null, it should return NIL, same process is applied at the end of this function
-		TRACE(TRACE_DEBUG, "hash_as_string: is null (missing): NIL");
-		list = g_list_append_printf(list, "NIL");
-		return list;
-	}
+	const char * gm_param_name;
+	const char * gm_param_value;
+	int i = 0;
+	int gm_param_len = 0;
 
-	TRACE(TRACE_DEBUG, "analyse [%s]", type);
-	while (type[i]) {
-		curr = type[i++];
-		if (curr == ';') {
-			break;
-		}
-	}
+	const char *gm_header = g_mime_object_get_header(mime_part, header);
 
-	while (type[i]) {
-		curr = type[i];
-		if (ISLF(curr) || ISCR(curr) || isblank(curr)) {
-			i++;
-			continue;
-		}
-		break;
-	}
-	
-	head += i;
-	//implementing a hard protection
-	int maxSize=strlen(head);
-	maxSize=strlen(head);
-	if (maxSize>1536)
-		maxSize=1536;//hard limit max len of name+len of value
-	int offset = 0;
-	int inname = 1;
-	TRACE(TRACE_DEBUG, "analyse [%s]", head);
-	while (head && maxSize>=0) {
-		//hard protection, preventing going maxsize, until the \0
-		maxSize--;
-		curr = head[offset];
-		if ((! curr) && (offset==0))
-			break;
-		if (curr == '=' && inname) {
-			memset(name, 0, sizeof(name));
-			if (offset>512) 
-				offset=512; //hard limit
-			strncpy(name, head, offset);
-			g_strstrip(name);
-			head += offset+1;
-			inname = 0;
-			offset = 0;
-			TRACE(TRACE_DEBUG, "name: %s", name);
-			l = g_list_append_printf(l, "\"%s\"", name);
-			continue;
-		} else if ((! curr) || (curr == ';')) {
-			size_t len;
-			char *clean1, *clean2, *clean3;
-			memset(value, 0, sizeof(value));
-			if (offset>1024) 
-				offset=1024; //hard limit
-			strncpy(value, head, offset);
-			head += offset+1;
-			inname = 1;
-			offset = 0;
-
-			clean1 = value;
-			if (clean1[0] == '"')
-				clean1++;
-
-			len = strlen(clean1);
-			if (clean1[len-1] == '"')
-				clean1[len-1] = '\0';
-
-			clean2 = g_strcompress(clean1);
-
-			if (g_mime_utils_text_is_8bit((const unsigned char *)clean2, strlen(clean2))) {
-				clean1 = g_mime_utils_header_encode_text(NULL, clean2, NULL);
-				g_free(clean2);
-				clean2 = clean1;
+	if(gm_header) {
+		gm_type = g_mime_object_get_content_type(mime_part);
+		if (gm_type) {
+			structure = g_list_append_printf(structure,"\"%s\"", gm_type->type);
+			structure = g_list_append_printf(structure,"\"%s\"", gm_type->subtype);
+			if (gm_type->params) {
+				gm_param_list = gm_type->params;
+				gm_param_len = g_mime_param_list_length(gm_param_list);
 			}
-			clean3 = g_strescape(clean2, NULL);
-			g_free(clean2);
-
-			TRACE(TRACE_DEBUG, "value: %s", value);
-			TRACE(TRACE_DEBUG, "clean: %s", clean3);
-			l = g_list_append_printf(l, "\"%s\"", clean3);
-
-			g_free(clean3);
-
-			if (! curr)
-				break;
+		} else {
+			TRACE(TRACE_DEBUG, "no type for mime part [%s]", header);
+			return structure;
 		}
-		offset ++;
+		if(gm_param_list) {
+			gm_param_len = g_mime_param_list_length(gm_param_list);
+		}
+		TRACE(TRACE_DEBUG,"parse [%s/%s]", gm_type->type, gm_type->subtype);
+
+		if (!gm_param_list) {
+			return structure;
+		}
+
+		for(i=0; i < gm_param_len; i++){
+			gm_param = g_mime_param_list_get_parameter_at(gm_param_list, i);
+			gm_param_name = g_mime_param_get_name(gm_param);
+			l = g_list_append_printf(l, "\"%s\"", gm_param_name);
+			gm_param_value = g_mime_param_get_value(gm_param);
+			gm_param_encoding = g_mime_param_get_encoding_method(gm_param);
+			if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_DEFAULT){
+				TRACE(TRACE_DEBUG, "encoding=default [%s]", gm_param_value);
+			} else if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_RFC2231){
+				TRACE(TRACE_DEBUG, "encoding=rfc2231 [%s]", gm_param_value);
+			} else if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_RFC2047){
+				TRACE(TRACE_DEBUG, "encoding=rfc2047 [%s]", gm_param_value);
+			} else {
+				TRACE(TRACE_DEBUG, "encoding=unknown [%s]", gm_param_value);
+			}
+			l = g_list_append_printf(l, "\"%s\"", gm_param_value);
+		}
 	}
 
 	if (l) {
 		char *s = dbmail_imap_plist_as_string(l);
-		TRACE(TRACE_DEBUG, "hash_as_string: from %s => %s", type, s);
-		list = g_list_append_printf(list, "%s", s);
+		structure = g_list_append_printf(structure, "%s", s);
 		g_free(s);
-		
 		g_list_destroy(l);
 	} else {
-		TRACE(TRACE_DEBUG, "hash_as_string: from %s => NIL",type);
-		list = g_list_append_printf(list, "NIL");
+		structure = g_list_append_printf(structure, "NIL");
 	}
-	
-
-	return list;
+	return structure;
 }
 
-static GList * imap_append_disposition_as_string(GList *list, GMimeObject *part)
+
+/* The returned disposition structure list is utf-8:
+ * (attachment ("filename" "name of file")) or NIL
+ */
+static GList * imap_append_disposition_as_string(GList *structure, GMimeObject *mime_part)
 {
-	GList *t = NULL;
-	GMimeContentDisposition *disposition;
-	char *result;
-	const char *disp = g_mime_object_get_header(part, "Content-Disposition");
-	
-	if(disp) {
-		disposition = g_mime_content_disposition_parse(NULL, disp);
-		t = g_list_append_printf(t,"\"%s\"",
-				g_mime_content_disposition_get_disposition(disposition));
-		
-		/* paramlist */
-		t = imap_append_hash_as_string(t, disp);
+	GMimeContentDisposition *gm_disposition;
+	GMimeParam * gm_param;
+	GMimeParamList * gm_param_list = NULL;
+	GMimeParamEncodingMethod gm_param_encoding;
+	GList *l = NULL;
+	int i = 0;
+	int gm_param_len = 0;
+	const char * gm_param_name;
+	const char * gm_param_value;
+	// const char * gm_param_charset;
+	const char *gm_header = g_mime_object_get_header(mime_part, "Content-Disposition");
 
-		g_object_unref(disposition);
-		
-		result = dbmail_imap_plist_as_string(t);
-		list = g_list_append_printf(list,"%s",result);
-		g_free(result);
-
-		g_list_destroy(t);
+	if (gm_header) {
+		gm_disposition = g_mime_content_disposition_parse(NULL, gm_header);
+		gm_param_list = g_mime_content_disposition_get_parameters(gm_disposition);
+		if(gm_param_list){
+			gm_param_len = g_mime_param_list_length(gm_param_list);
+		} else {
+			return structure;
+		}
+		// Add param values
+		for(i=0; i < gm_param_len; i++){
+			gm_param = g_mime_param_list_get_parameter_at(gm_param_list, i);
+			gm_param_name = g_mime_param_get_name(gm_param);
+			l = g_list_append_printf(l, "\"%s\"", gm_param_name);
+			gm_param_value = g_mime_param_get_value(gm_param);
+			gm_param_encoding = g_mime_param_get_encoding_method(gm_param);
+			if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_DEFAULT){
+				TRACE(TRACE_DEBUG, "encoding=default [%s]", gm_param_value);
+			} else if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_RFC2231){
+				TRACE(TRACE_DEBUG, "encoding=rfc2231 [%s]", gm_param_value);
+			} else if (gm_param_encoding == GMIME_PARAM_ENCODING_METHOD_RFC2047){
+				TRACE(TRACE_DEBUG, "encoding=rfc2047 [%s]", gm_param_value);
+			} else {
+				TRACE(TRACE_DEBUG, "encoding=unknown [%s]", gm_param_value);
+			}
+			// gm_param_charset = g_mime_param_get_charset(gm_param);
+			// if (gm_param_charset) {
+			// 	l = g_list_append_printf(l, "\"%s\"", gm_param_charset);
+			// }
+			l = g_list_append_printf(l, "\"%s\"", gm_param_value);
+		}
+		if (l) {
+			gm_param_value = g_mime_content_disposition_get_disposition(gm_disposition);
+			char *s = dbmail_imap_plist_as_string(l);
+			TRACE(TRACE_DEBUG, "content_disposition_as_string [%s]", s);
+			structure = g_list_append_printf(structure, "(\"%s\" %s)", gm_param_value, s);
+			g_free(s);
+			g_list_destroy(l);
+		} else {
+			structure = g_list_append_printf(structure, "(\"%s\" NIL)", gm_header);
+		}
+		g_object_unref(gm_disposition);
 	} else {
-		list = g_list_append_printf(list,"NIL");
+		structure = g_list_append_printf(structure,"NIL");
 	}
-	return list;
+	return structure;
 }
 
-#define imap_append_header_as_string(list, part, header) \
-	imap_append_header_as_string_default(list, part, header, "NIL")
-
-static GList * imap_append_header_as_string_default(GList *list,
+static GList * imap_append_header_value(GList *structure,
 		GMimeObject *part, const char *header, char *def)
 {
-	char *result;
-	char *s;
-	if((result = (char *)g_mime_object_get_header(part, header))) {
-		s = dbmail_imap_astring_as_string(result);
-		list = g_list_append_printf(list, "%s", s);
-		g_free(s);
+	const char *result;
+	if((result = g_mime_object_get_header(part, header))) {
+		structure = g_list_append_printf(structure, "\"%s\"", result);
 	} else {
-		list = g_list_append_printf(list, def);
+		structure = g_list_append_printf(structure, "%s", def);
 	}
-	return list;
+	return structure;
 }
 
 static void imap_part_get_sizes(GMimeObject *part, size_t *size, size_t *lines)
@@ -1693,39 +1680,38 @@ static void imap_part_get_sizes(GMimeObject *part, size_t *size, size_t *lines)
 }
 
 
-void _structure_part_handle_part(GMimeObject *part, gpointer data, gboolean extension)
+static GList * _structure_part_handle_part(GMimeObject *part, GList *structure, gboolean extension)
 {
 	GMimeContentType *type;
 	GMimeObject *object;
 
-//	if (GMIME_IS_MESSAGE(part))
-//		object = g_mime_message_get_mime_part(GMIME_MESSAGE(part));
-//	else
-//		object = part;
-	object = part;
+	if (GMIME_IS_MESSAGE(part))
+		object = g_mime_message_get_mime_part(GMIME_MESSAGE(part));
+	else
+		object = part;
 	
 	type = g_mime_object_get_content_type(object);
 	if (! type) {
 		TRACE(TRACE_DEBUG, "no type for object!");
-		return;
+		return structure;
 	}
 
 	TRACE(TRACE_DEBUG,"parse [%s/%s]", type->type, type->subtype);
 
 	/* multipart composite */
 	if (g_mime_content_type_is_type(type,"multipart","*"))
-		_structure_part_multipart(object,data, extension);
+		structure = _structure_part_multipart(object, structure, extension);
 	/* message included as mimepart */
 	else if (g_mime_content_type_is_type(type,"message","*"))
-		_structure_part_message(object,data, extension);
+		structure = _structure_part_message(object, structure, extension);
 	/* simple message */
 	else
-		_structure_part_text(object,data, extension);
+		structure = _structure_part_text(object, structure, extension);
 
-
+	return structure;
 }
 
-void _structure_part_multipart(GMimeObject *part, gpointer data, gboolean extension)
+static GList * _structure_part_multipart(GMimeObject *part, GList *structure, gboolean extension)
 {
 	GMimeMultipart *multipart;
 	GMimeObject *subpart, *object;
@@ -1735,37 +1721,37 @@ void _structure_part_multipart(GMimeObject *part, gpointer data, gboolean extens
 	int i,j;
 	GMimeContentType *type;
 	
+	if (GMIME_IS_MESSAGE(part))
+		object = g_mime_message_get_mime_part(GMIME_MESSAGE(part));
+	else
+		object = part;
 	object = part;
 	
 	type = g_mime_object_get_content_type(object);
 	if (! type) {
 		TRACE(TRACE_DEBUG, "no type information");
-		return;
+		return structure;
 	}
 	multipart = GMIME_MULTIPART(object);
 	i = g_mime_multipart_get_count(multipart);
 	
-	TRACE(TRACE_DEBUG,"parse [%d] parts for [%s/%s] with boundary [%s]", 
+	TRACE(TRACE_DEBUG,"parse [%d] parts for [%s/%s] with boundary [%s]",
 			i, type->type, type->subtype,
 		       	g_mime_multipart_get_boundary(multipart));
 
 	/* loop over parts for base info */
 	for (j=0; j<i; j++) {
 		subpart = g_mime_multipart_get_part(multipart,j);
-		_structure_part_handle_part(subpart,&alist,extension);
+		alist = _structure_part_handle_part(subpart, alist, extension);
 	}
-	
-	/* sub-type */
-	alist = g_list_append_printf(alist,"\"%s\"", type->subtype);
 
-	/* extension data (only for multipart, in case of BODYSTRUCTURE command argument) */
 	if (extension) {
 		/* paramlist */
-		list = imap_append_hash_as_string(list, 
-				g_mime_object_get_header(object, "Content-Type"));
-
+		list = imap_append_header_as_string(list,object,"Content-Type");
 		/* disposition */
 		list = imap_append_disposition_as_string(list, object);
+		/* description */
+		list = imap_append_header_value(list,object,"Content-Description", "NIL");
 		/* language */
 		list = imap_append_header_as_string(list,object,"Content-Language");
 		/* location */
@@ -1779,10 +1765,11 @@ void _structure_part_multipart(GMimeObject *part, gpointer data, gboolean extens
 	}
 
 	/* done*/
-	*(GList **)data = (gpointer)g_list_append(*(GList **)data,dbmail_imap_plist_as_string(alist));
+	structure = g_list_append(structure, dbmail_imap_plist_as_string(alist));
 	
 	g_list_destroy(alist);
 
+	return structure;
 }
 
 static GList * _structure_basic(GMimeObject *object)
@@ -1798,26 +1785,25 @@ static GList * _structure_basic(GMimeObject *object)
 	}
 	TRACE(TRACE_DEBUG, "parse [%s/%s]", type->type, type->subtype);
 
-	/* type/subtype */
-	list = g_list_append_printf(list,"\"%s\"", type->type);
-	list = g_list_append_printf(list,"\"%s\"", type->subtype);
 	/* paramlist */
-	list = imap_append_hash_as_string(list, 
-			g_mime_object_get_header(object, "Content-Type"));
+	list = imap_append_header_as_string(list, object, "Content-Type");
+
 	/* body id */
 	if ((result = (char *)g_mime_object_get_content_id(object)))
 		list = g_list_append_printf(list,"\"%s\"", result);
 	else
 		list = g_list_append_printf(list,"NIL");
+
 	/* body description */
-	list = imap_append_header_as_string(list,object,"Content-Description");
+	list = imap_append_header_value(list,object,"Content-Description", "NIL");
+
 	/* body encoding */
-	list = imap_append_header_as_string_default(list,object,"Content-Transfer-Encoding", "\"7BIT\"");
+	list = imap_append_header_value(list,object,"Content-Transfer-Encoding", "\"7BIT\"");
 
 	return list;
 
 }
-void _structure_part_message(GMimeObject *part, gpointer data, gboolean extension)
+static GList * _structure_part_message(GMimeObject *part, GList *structure, gboolean extension)
 {
 	char *b;
 	GList *list = NULL;
@@ -1826,6 +1812,7 @@ void _structure_part_message(GMimeObject *part, gpointer data, gboolean extensio
 	
 	object = part;
 	
+	list = g_list_append_printf(list,"_structure_part_message");
 	list = _structure_basic(object);
 
 	/* body size */
@@ -1859,13 +1846,14 @@ void _structure_part_message(GMimeObject *part, gpointer data, gboolean extensio
 	}
 	
 	/* done*/
-	*(GList **)data = (gpointer)g_list_append(*(GList **)data,dbmail_imap_plist_as_string(list));
+	structure = g_list_append(structure, dbmail_imap_plist_as_string(list));
 	
 	g_list_destroy(list);
 
+	return structure;
 }
 
-void _structure_part_text(GMimeObject *part, gpointer data, gboolean extension)
+static GList * _structure_part_text(GMimeObject *part, GList *structure, gboolean extension)
 {
 	GList *list = NULL;
 	size_t s = 0, l = 0;
@@ -1900,13 +1888,12 @@ void _structure_part_text(GMimeObject *part, gpointer data, gboolean extension)
 	}
 	
 	/* done*/
-	*(GList **)data = (gpointer)g_list_append(*(GList **)data, dbmail_imap_plist_as_string(list));
-	
+	structure = g_list_append(structure, dbmail_imap_plist_as_string(list));
+
 	g_list_destroy(list);
 
+	return structure;
 }
-
-
 
 GList* dbmail_imap_append_alist_as_plist(GList *list, InternetAddressList *ialist)
 {
@@ -2004,7 +1991,7 @@ GList* dbmail_imap_append_alist_as_plist(GList *list, InternetAddressList *ialis
 			p = g_list_append_printf(p, "%s", s);
 			g_free(s);
 
-			// Dont free list data, it's free'd elsewhere
+			// Dont free list structure, it's free'd elsewhere
 			g_list_destroy(t);
 			t = NULL;
 		}
@@ -2055,31 +2042,30 @@ char * imap_get_structure(GMimeMessage *message, gboolean extension)
 	
 	/* multipart composite */
 	if (g_mime_content_type_is_type(type,"multipart","*"))
-		_structure_part_multipart(part,(gpointer)&structure, extension);
+		structure = _structure_part_multipart(part, structure, extension);
 	/* message included as mimepart */
 	else if (g_mime_content_type_is_type(type,"message","*"))
-		_structure_part_message(part,(gpointer)&structure, extension);
+		structure = _structure_part_message(part, structure, extension);
 	/* as simple message */
 	else
-		_structure_part_text(part,(gpointer)&structure, extension);
+		structure = _structure_part_text(part, structure, extension);
 	
 	s = dbmail_imap_plist_as_string(structure);
 	t = dbmail_imap_plist_collapse(s);
 	g_free(s);
 
 	g_list_destroy(structure);
-	
+
 	return t;
 }
 
-static GList * envelope_address_part(GList *list, GMimeMessage *message, const char *header)
+GList * envelope_address_part(GList *list, GMimeMessage *message, const char *header)
 {
 	const char *result;
 	char *t;
 	InternetAddressList *alist;
 
 	result = g_mime_object_get_header(GMIME_OBJECT(message),header);
-
 	if (result) {
 		t = imap_cleanup_address(result);
 		alist = internet_address_list_parse(NULL, t);
@@ -2138,30 +2124,18 @@ char * imap_get_envelope(GMimeMessage *message)
 
 	if (! GMIME_IS_MESSAGE(message))
 		return NULL;
-	
+
 	part = GMIME_OBJECT(message);
+
 	/* date */
-	result = g_mime_object_get_header(part, "Date");
-	if (result) {
-		t = dbmail_imap_astring_as_string(result);
-		list = g_list_append_printf(list,"%s", t);
-		g_free(t);
-	} else {
-		list = g_list_append_printf(list,"NIL");
-	}
+	list = imap_append_header_value(list, part, "Date", "NIL");
 	
 	/* subject */
-	result = g_mime_object_get_header(GMIME_OBJECT(message),"Subject");
-
-	if (result) {
-		list = g_list_append_printf(list,"\"%s\"", result);
-		g_free(t);
-	} else {
-		list = g_list_append_printf(list,"NIL");
-	}
+	list = imap_append_header_value(list, part, "Subject", "NIL");
 	
 	/* from */
 	list = envelope_address_part(list, message, "From");
+
 	/* sender */
 	h = g_mime_object_get_header(GMIME_OBJECT(message),"Sender");
 	if (h && (strlen(h) > 0))
@@ -2175,16 +2149,16 @@ char * imap_get_envelope(GMimeMessage *message)
 		list = envelope_address_part(list, message, "Reply-to");
 	else
 		list = envelope_address_part(list, message, "From");
-		
+
 	/* to */
 	list = envelope_address_part(list, message, "To");
 	/* cc */
 	list = envelope_address_part(list, message, "Cc");
 	/* bcc */
 	list = envelope_address_part(list, message, "Bcc");
-	
 	/* in-reply-to */
-	list = imap_append_header_as_string(list,part,"In-Reply-to");
+	list = imap_append_header_value(list, part, "In-Reply-to", "NIL");
+
 	/* message-id */
 	result = g_mime_message_get_message_id(message);
 	if (result && (! g_strrstr(result,"=")) && (! g_strrstr(result,"@(none)"))) {
@@ -2199,7 +2173,7 @@ char * imap_get_envelope(GMimeMessage *message)
 
 	s = dbmail_imap_plist_as_string(list);
 
-	// Dont free list data, it's free'd elsewhere
+	// Dont free list structure, it's free'd elsewhere
 	g_list_destroy(list);
 
 	return s;
@@ -2588,5 +2562,3 @@ int diff_time(struct timeval before, struct timeval after)
 	int tdiff = tafter - tbefore;
 	return (int)rint((double)tdiff/1000000);
 }
-
-

--- a/test/check_dbmail.h
+++ b/test/check_dbmail.h
@@ -62,7 +62,7 @@ char *simple_groups = "From user@domain  Fri Feb 22 17:06:23 2008\n"
 	"body\n"
 	"\n";
 
-char *rfc822 = "From nobody Wed Sep 14 16:47:48 2005\n" 
+char *rfc822 = "From nobody Wed Sep 14 16:47:48 2005\n"
 	"Content-Type: text/plain; charset=\"us-ascii\"\n"
 	"MIME-Version: 1.0\n"
 	"Content-Transfer-Encoding: 7bit\n"
@@ -1276,20 +1276,20 @@ char * broken_message3 = "Message-ID: <002001ca32fe$dc7668b0$9600000a@ricardo>\n
 	"MIME-Version: 1.0\n\n"
 	"\ntest\n";
 	
-char * broken_message4 = "Return-Path: Alan Hicks <ahicks@p-o.co.uk>\n"
+char * broken_message4 = "Return-Path: Bombeiros Vol. Mortágua\n"
 	"Received: from alan by p-o.co.uk\n"
 	"	with local (Exim 4.95 (FreeBSD))	(envelope-from <alan@p-o.co.uk>)\n"
 	"	id 1no8eq-000Ie5-02	for alan@p-o.co.uk;	Tue, 31 May 202225 20:03:00 +0100\n"
-	"From: Alan Hicks <ahicks@p-o.co.uk>\n"
-	"To: ahicks@p-o.co.uk\n"
+	"From: =?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\n"
+	"To: Foo Bar <foo@bar.pt>\n"
 	"Subject: Broken test message 4 with invalid date\n"
 	"Message-Id: <broken-test-04@p-o.co.uk>\n"
 	"Date: Fri, 3 Jun 202225 20:03:00 +0100\n\n"
 	"Test line 1\n"
 	"Test line 2\n";
 
-char * broken_message5 = "From Alan Hicks <ahicks@p-o.co.uk>\n"
-	"From: Alan Hicks <ahicks@p-o.co.uk>\n"
+char * broken_message5 = "From Bombeiros Vol. Mortágua\n"
+	"From: =?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\n"
 	"To: ahicks@p-o.co.uk\n"
 	"Subject: Broken test message 5 without body\n"
 	"Message-Id: <broken-test-05@p-o.co.uk>\n"

--- a/test/check_dbmail.h
+++ b/test/check_dbmail.h
@@ -577,6 +577,8 @@ const char *multipart_message6 = "From: nobody@nowhere.org\n"
 	"[HTML content]\n"
 	"------=_Part_228805_1858578062.1329804655776-- \n"
 	"\n"
+	"------=_Part_228806_1971825612.1329804655776--\n"
+	"\n"
 	"------=_Part_228805_1858578061.1329804655776\n"
 	"Content-Type: image/png; name=logo.png\n"
 	"Content-Transfer-Encoding: base64\n"
@@ -625,7 +627,7 @@ const char *multipart_message6 = "From: nobody@nowhere.org\n"
 	"Content-Description: /icon3.png\n"
 	"\n"
 	"[PNG CONTENT]\n"
-	"------=_Part_228805_1858578061.1329804655776-- \n";
+	"------=_Part_228805_1858578061.1329804655776--\n";
 
 char *outlook_multipart = "From aprilbabies-bounces@lists.nfg.nl  Fri Nov 25 22: 34:35 2005\n"
 	"From: \"Foo Bar\" <foobar@foo.bar>\n"
@@ -815,7 +817,8 @@ char *encoded_message_utf8_2 = "X-Mozilla-Status: 0001\n"
 
 char *utf8_long_header =
 "Subject: =?UTF-8?B?0J/RgNC40LzQtdGAINC00L7RgdGC0LDRgtC+0YfQvdC+INC00Ls=?=\n"
-" =?UTF-8?B?0LjQvdC90L7Qs9C+INGC0LXQutGB0YLQsCDQsiDQv9C+0LvQtQ==?= Subject\n"
+" =?UTF-8?B?0LjQvdC90L7Qs9C+INGC0LXQutGB0YLQsCDQsiDQv9C+0LvQtQ==?=\n"
+" =?iso-8859-1?Q? Subject ?=\n"
 " =?UTF-8?B?0LIg0LzQvdC+0LPQvtCx0LDQudGC0L7QstGL0YUg0YHQuNC80LLQvtC70LA=?=\n"
 " =?UTF-8?B?0YUgKNC90LDQv9GA0LjQvNC10YAsINC90LDQv9C40YHQsNC90L3Ri9GFINC9?=\n"
 " =?UTF-8?B?0LAg0YDRg9GB0YHQutC+0Lwg0Y/Qt9GL0LrQtSkg0L/RgNC40LLQvtC00Lg=?=\n"

--- a/test/check_dbmail_common.c
+++ b/test/check_dbmail_common.c
@@ -119,5 +119,3 @@ int main(void)
 	srunner_free(sr);
 	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-	
-

--- a/test/check_dbmail_imapd.c
+++ b/test/check_dbmail_imapd.c
@@ -358,7 +358,7 @@ START_TEST(test_imap_get_envelope)
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, rfc822);
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
 	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
 
 	dbmail_message_free(message);
@@ -370,7 +370,7 @@ START_TEST(test_imap_get_envelope)
 	message = dbmail_message_init_with_string(message, simple);
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
 
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"dbmail test message\" NIL NIL NIL NIL NIL NIL NIL NIL)", 1024);
+	strncpy(expect,"(NIL \"dbmail test message\" NIL NIL NIL NIL NIL NIL NIL NIL)", 1024);
 	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
 
 	dbmail_message_free(message);
@@ -437,13 +437,13 @@ START_TEST(test_imap_get_envelope_8bit_id)
 	dbmail_message_set_header(message,"Message-ID",msgid);
 	
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
 	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed");
 	g_free(result);
 	
 	dbmail_message_set_header(message,"Message-ID","<123123123@foo.bar>");
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL \"<123123123@foo.bar>\")",1024);
+	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL \"<123123123@foo.bar>\")",1024);
 	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed");
 
 	dbmail_message_free(message);
@@ -455,7 +455,7 @@ END_TEST
 START_TEST(test_imap_get_envelope_koi)
 {
 	char *t;
-	const char *exp = "(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"test\" ((\"=?iso-8859-5?b?sN3i3t0gvdXl3uDe6Njl?=\" NIL \"bad\" \"foo.ru\")) ((\"=?iso-8859-5?b?sN3i3t0gvdXl3uDe6Njl?=\" NIL \"bad\" \"foo.ru\")) ((\"=?iso-8859-5?b?sN3i3t0gvdXl3uDe6Njl?=\" NIL \"bad\" \"foo.ru\")) ((NIL NIL \"nobody\" \"foo.ru\")) NIL NIL NIL NIL)";
+	const char *exp = "(NIL \"test\" ((\"Антон Нехороших\" NIL \"bad\" \"foo.ru\")) ((\"Антон Нехороших\" NIL \"bad\" \"foo.ru\")) ((\"Антон Нехороших\" NIL \"bad\" \"foo.ru\")) ((NIL NIL \"nobody\" \"foo.ru\")) NIL NIL NIL NIL)";
 	DbmailMessage *m = dbmail_message_new(NULL);
 
 	m = dbmail_message_init_with_string(m, encoded_message_koi);
@@ -516,7 +516,7 @@ START_TEST(test_imap_get_envelope_latin)
 	
 	t = imap_get_envelope(GMIME_MESSAGE(m->content));
 	
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"=?iso-8859-1?Q?Re:_M=F3dulo_Extintores?=\" ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"=?iso-8859-1?Q?Re:_M=F3dulo_Extintores?=\" ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
 	
 //	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);
 
@@ -527,7 +527,7 @@ START_TEST(test_imap_get_envelope_latin)
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m, encoded_message_latin_2);
 	
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"=?ISO-8859-2?Q?Re=3A_=5Bgentoo-dev=5D_New_developer=3A__?= =?ISO-8859-2?Q?Miroslav_=A9ulc_=28fordfrog=29?=\" ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((NIL NIL \"gentoo-dev\" \"lists.gentoo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"=?ISO-8859-2?Q?Re=3A_=5Bgentoo-dev=5D_New_developer=3A__?= =?ISO-8859-2?Q?Miroslav_=A9ulc_=28fordfrog=29?=\" ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((NIL NIL \"gentoo-dev\" \"lists.gentoo.org\")) NIL NIL NIL NIL)",1024);
 	t = imap_get_envelope(GMIME_MESSAGE(m->content));
 	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);
 	
@@ -538,7 +538,7 @@ START_TEST(test_imap_get_envelope_latin)
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m, encoded_message_utf8);
 
-	strncpy(expect,"(\"Thu, 01 Jan 1970 00:00:00 +0000\" \"=?utf-8?b?w6nDqcOp?=\" ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"=?utf-8?b?w6nDqcOp?=\" ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
 
 	t = imap_get_envelope(GMIME_MESSAGE(m->content));
 	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);

--- a/test/check_dbmail_imapd.c
+++ b/test/check_dbmail_imapd.c
@@ -191,10 +191,9 @@ START_TEST(test_imap_session_new)
 }
 END_TEST
 
-START_TEST(test_imap_get_structure)
+START_TEST(test_imap_get_structure_bare_bones)
 {
 	DbmailMessage *message;
-	char *body;
 	char *result;
 	char expect[4096];
 
@@ -207,16 +206,37 @@ START_TEST(test_imap_get_structure)
 	dbmail_message_free(message);
 	g_free(result);
 
+}
+END_TEST
+START_TEST(test_imap_get_structure_text_plain)
+{
+	DbmailMessage *message;
+	char *body;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
+
 	/* text/plain */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, rfc822);
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
 	strncpy(expect,"(\"text\" \"plain\" (\"charset\" \"us-ascii\") NIL NIL \"7bit\" 32 4 NIL NIL NIL NIL)",1024);
 	body = g_mime_object_get_body(message->content);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_structure failed\n[%s]!=\n[%s]\n[%s]\n", result, expect, body);
+	ck_assert_str_eq(result, expect);
 	g_free(body);
 	g_free(result);
 	dbmail_message_free(message);
+
+}
+END_TEST
+START_TEST(test_imap_get_structure_multipart)
+{
+	DbmailMessage *message;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
 
 	/* multipart */
 	message = dbmail_message_new(NULL);
@@ -224,44 +244,83 @@ START_TEST(test_imap_get_structure)
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
 	strncpy(expect,"((\"text\" \"html\" NIL NIL NIL \"7BIT\" 30 3 NIL (\"inline\" NIL) NIL NIL)"
 			"(\"text\" \"plain\" (\"charset\" \"us-ascii\" \"name\" \"testfile\") NIL NIL \"base64\" 432 7 NIL NIL NIL NIL)"
-			" \"mixed\" (\"boundary\" \"boundary\") NIL NIL NIL)",1024);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_structure failed\n[%s] !=\n[%s]\n", expect, result);
+			" \"multipart\" \"mixed\" (\"boundary\" \"boundary\") NIL NIL NIL NIL)",1024);
+	ck_assert_str_eq(result, expect);
 	g_free(result);
 	dbmail_message_free(message);
+
+}
+END_TEST
+START_TEST(test_imap_get_structure_multipart_alternative)
+{
+	DbmailMessage *message;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
 
 	/* multipart alternative */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_alternative);
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
-	strncpy(expect,"(((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"7bit\" 281 10 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"7bit\" 759 17 NIL NIL NIL NIL) \"alternative\" (\"boundary\" \"------------040302030903000400040101\") NIL NIL NIL)(\"image\" \"jpeg\" (\"name\" \"jesse_2.jpg\") NIL NIL \"base64\" 262 NIL (\"inline\" (\"filename\" \"jesse_2.jpg\")) NIL NIL) \"mixed\" (\"boundary\" \"------------050000030206040804030909\") NIL NIL NIL)",1024);
+	strncpy(expect,"(((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"7bit\" 281 10 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"7bit\" 759 17 NIL NIL NIL NIL) \"multipart\" \"alternative\" (\"boundary\" \"------------040302030903000400040101\") NIL NIL NIL NIL)(\"image\" \"jpeg\" (\"name\" \"jesse_2.jpg\") NIL NIL \"base64\" 262 NIL (\"inline\" (\"filename\" \"jesse_2.jpg\")) NIL NIL) \"multipart\" \"mixed\" (\"boundary\" \"------------050000030206040804030909\") NIL NIL NIL NIL)",1024);
 
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_structure failed\n[%s]!=\n[%s]\n", result, expect);
+	ck_assert_str_eq(result, expect);
 	g_free(result);
 	dbmail_message_free(message);
+}
+END_TEST
+START_TEST(test_imap_get_structure_multipart_apple)
+{
+	DbmailMessage *message;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
+
 	/* multipart apple */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_apple);
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
-	strncpy(expect, "((\"text\" \"plain\" (\"charset\" \"windows-1252\") NIL NIL \"quoted-printable\" 6 2 NIL NIL NIL NIL)((\"text\" \"html\" (\"charset\" \"us-ascii\") NIL NIL \"7bit\" 39 1 NIL NIL NIL NIL)(\"application\" \"vnd.openxmlformats-officedocument.wordprocessingml.document\" (\"name\" \"=?windows-1252?Q?=84Tradition_hat_Potenzial=5C=22=2Edocx?=\") NIL NIL \"base64\" 256 NIL (\"attachment\" (\"filename*\" \"windows-1252''%84Tradition%20hat%20Potenzial%22.docx\")) NIL NIL)(\"text\" \"html\" (\"charset\" \"windows-1252\") NIL NIL \"quoted-printable\" 147 4 NIL NIL NIL NIL) \"mixed\" (\"boundary\" \"Apple-Mail=_3A2FC16D-D077-44C8-A239-A7B36A86540F\") NIL NIL NIL) \"alternative\" (\"boundary\" \"Apple-Mail=_E6A72268-1DAC-4E40-8270-C4CBE68157E0\") NIL NIL NIL)", 1024);
-
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_structure failed\n[%s]!=\n[%s]\n", result, expect);
+	strncpy(expect, "((\"text\" \"plain\" (\"charset\" \"windows-1252\") NIL NIL \"quoted-printable\" 6 2 NIL NIL NIL NIL)((\"text\" \"html\" (\"charset\" \"us-ascii\") NIL NIL \"7bit\" 39 1 NIL NIL NIL NIL)(\"application\" \"vnd.openxmlformats-officedocument.wordprocessingml.document\" (\"name\" \"„Tradition hat Potenzial\".docx\") NIL NIL \"base64\" 256 NIL (\"attachment\" (\"filename\" \"„Tradition hat Potenzial\".docx\")) NIL NIL)(\"text\" \"html\" (\"charset\" \"windows-1252\") NIL NIL \"quoted-printable\" 147 4 NIL NIL NIL NIL) \"multipart\" \"mixed\" (\"boundary\" \"Apple-Mail=_3A2FC16D-D077-44C8-A239-A7B36A86540F\") NIL NIL NIL NIL) \"multipart\" \"alternative\" (\"boundary\" \"Apple-Mail=_E6A72268-1DAC-4E40-8270-C4CBE68157E0\") NIL NIL NIL NIL)", 4096);
+	ck_assert_str_eq(result, expect);
 	g_free(result);
 	dbmail_message_free(message);
+}
+END_TEST
+START_TEST(test_imap_get_structure_rfc2231)
+{
+	DbmailMessage *message;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
+
 	/* rfc2231 encoded content-disposition */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_message7);
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
-	strncpy(expect, "((\"text\" \"plain\" (\"charset\" \"UTF-8\") NIL NIL \"7bit\" 9 2 NIL NIL NIL NIL)(\"image\" \"png\" (\"name\" \"=?UTF-8?B?cGjDtm5ueS5wbmc=?=\") NIL NIL \"base64\" 225 NIL (\"attachment\" (\"filename*\" \"UTF-8''%70%68%C3%B6%6E%6E%79%2E%70%6E%67\")) NIL NIL) \"mixed\" (\"boundary\" \"------------000706040608020005040505\") NIL NIL NIL)", 1024);
+	strncpy(expect, "((\"text\" \"plain\" (\"charset\" \"UTF-8\") NIL NIL \"7bit\" 9 2 NIL NIL NIL NIL)(\"image\" \"png\" (\"name\" \"phönny.png\") NIL NIL \"base64\" 225 NIL (\"attachment\" (\"filename\" \"phönny.png\")) NIL NIL) \"multipart\" \"mixed\" (\"boundary\" \"------------000706040608020005040505\") NIL NIL NIL NIL)", 1024);
 
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_structure failed\n[%s]!=\n[%s]\n", result, expect);
+	ck_assert_str_eq(result, expect);
 	g_free(result);
 	dbmail_message_free(message);
+}
+END_TEST
+START_TEST(test_imap_get_structure_multipart_signed)
+{
+	DbmailMessage *message;
+	char *result;
+	char expect[4096];
+
+	memset(&expect, 0, sizeof(expect));
 
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_signed);
 	result = imap_get_structure(GMIME_MESSAGE(message->content), 1);
-	strncpy(expect, "(((\"text\" \"plain\" (\"charset\" \"UTF-8\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"image\" \"gif\" (\"name\" \"image.gif\") NIL NIL \"base64\" 142 NIL (\"attachment\" (\"filename\" \"image.gif\")) NIL NIL)(\"message\" \"rfc822\" NIL NIL NIL \"7bit\" 610 (\"Mon, 19 Aug 2013 14:54:05 +0200\" \"msg1\" ((NIL NIL \"d\" \"b\"))((NIL NIL \"d\" \"b\"))((NIL NIL \"e\" \"b\"))((NIL NIL \"a\" \"b\")) NIL NIL NIL NIL)((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 11 2 NIL NIL NIL NIL) \"alternative\" (\"boundary\" \"b1_7ad0d7cccab59d27194f9ad69c14606001f05f531376916845\") NIL NIL NIL) 26 NIL (\"attachment\" (\"filename\" \"msg1.eml\")) NIL NIL)(\"message\" \"rfc822\" (\"name\" \"msg2.eml\") NIL NIL \"7bit\" 608 (\"Mon, 19 Aug 2013 14:54:05 +0200\" \"msg2\" ((NIL NIL \"d\" \"b\"))((NIL NIL \"d\" \"b\"))((NIL NIL \"e\" \"b\"))((NIL NIL \"a\" \"b\")) NIL NIL NIL NIL)((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 11 2 NIL NIL NIL NIL) \"alternative\" (\"boundary\" \"b1_7ad0d7cccab59d27194f9ad69c14606001f05f531376916845\") NIL NIL NIL) 25 NIL (\"attachment\" (\"filename\" \"msg2.eml\")) NIL NIL)(\"application\" \"x-php\" (\"name\" \"script.php\") NIL NIL \"base64\" 122 NIL (\"attachment\" (\"filename\" \"script.php\")) NIL NIL) \"mixed\" (\"boundary\" \"------------090808030504030005030705\") NIL NIL NIL)(\"application\" \"pgp-signature\" (\"name\" \"signature.asc\") NIL \"OpenPGP digital signature\" \"7BIT\" 271 NIL (\"attachment\" (\"filename\" \"signature.asc\")) NIL NIL) \"signed\" (\"micalg\" \"pgp-sha1\" \"protocol\" \"application/pgp-signature\" \"boundary\" \"DQGSJUrIXg9lgq2GBFumjRDhuJtiugxAX\") NIL NIL NIL)", 4096);
-	fail_unless(strncasecmp(result,expect,4096)==0, "imap_get_structure failed\n[%s]!=\n[%s]\n", result, expect);
+	strncpy(expect, "(((\"text\" \"plain\" (\"charset\" \"UTF-8\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"image\" \"gif\" (\"name\" \"image.gif\") NIL NIL \"base64\" 142 NIL (\"attachment\" (\"filename\" \"image.gif\")) NIL NIL)(\"message\" \"rfc822\" NIL NIL NIL \"7bit\" 610 (\"Mon, 19 Aug 2013 14:54:05 +0200\" \"msg1\" ((NIL NIL \"d\" \"b\"))((NIL NIL \"d\" \"b\"))((NIL NIL \"e\" \"b\"))((NIL NIL \"a\" \"b\")) NIL NIL NIL NIL)((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 11 2 NIL NIL NIL NIL) \"multipart\" \"alternative\" (\"boundary\" \"b1_7ad0d7cccab59d27194f9ad69c14606001f05f531376916845\") NIL NIL NIL NIL) 26 NIL (\"attachment\" (\"filename\" \"msg1.eml\")) NIL NIL)(\"message\" \"rfc822\" (\"name\" \"msg2.eml\") NIL NIL \"7bit\" 608 (\"Mon, 19 Aug 2013 14:54:05 +0200\" \"msg2\" ((NIL NIL \"d\" \"b\"))((NIL NIL \"d\" \"b\"))((NIL NIL \"e\" \"b\"))((NIL NIL \"a\" \"b\")) NIL NIL NIL NIL)((\"text\" \"plain\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 12 1 NIL NIL NIL NIL)(\"text\" \"html\" (\"charset\" \"ISO-8859-1\") NIL NIL \"quoted-printable\" 11 2 NIL NIL NIL NIL) \"multipart\" \"alternative\" (\"boundary\" \"b1_7ad0d7cccab59d27194f9ad69c14606001f05f531376916845\") NIL NIL NIL NIL) 25 NIL (\"attachment\" (\"filename\" \"msg2.eml\")) NIL NIL)(\"application\" \"x-php\" (\"name\" \"script.php\") NIL NIL \"base64\" 122 NIL (\"attachment\" (\"filename\" \"script.php\")) NIL NIL) \"multipart\" \"mixed\" (\"boundary\" \"------------090808030504030005030705\") NIL NIL NIL NIL)(\"application\" \"pgp-signature\" (\"name\" \"signature.asc\") NIL \"OpenPGP digital signature\" \"7BIT\" 271 NIL (\"attachment\" (\"filename\" \"signature.asc\")) NIL NIL) \"multipart\" \"signed\" (\"micalg\" \"pgp-sha1\" \"protocol\" \"application/pgp-signature\" \"boundary\" \"DQGSJUrIXg9lgq2GBFumjRDhuJtiugxAX\") NIL NIL NIL NIL)", 4096);
+
+	ck_assert_str_eq(result, expect);
 	g_free(result);
 	dbmail_message_free(message);
 	/* done */
@@ -351,67 +410,16 @@ START_TEST(test_imap_get_envelope)
 {
 	DbmailMessage *message;
 	char *result, *expect;
-	
+
 	expect = g_new0(char, 1024);
-	
+
 	/* text/plain */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, rfc822);
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
 	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
 
-	dbmail_message_free(message);
-	g_free(result);
-	result = NULL;
-
-	/* bare bones message */
-	message = dbmail_message_new(NULL);
-	message = dbmail_message_init_with_string(message, simple);
-	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-
-	strncpy(expect,"(NIL \"dbmail test message\" NIL NIL NIL NIL NIL NIL NIL NIL)", 1024);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
-
-	dbmail_message_free(message);
-	g_free(result);
-	result = NULL;
-
-	/* bare bones message with group addresses*/
-	message = dbmail_message_new(NULL);
-	message = dbmail_message_init_with_string(message, simple_groups);
-	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-
-	strncpy(expect,"(\"Thu, 15 feb 2007 01:02:03 +0200\" NIL ((\"Real Name\" NIL \"user\" \"domain\")) ((\"Real Name\" NIL \"user\" \"domain\")) ((\"Real Name\" NIL \"user\" \"domain\")) ((NIL NIL \"group\" NIL)(NIL NIL \"g1\" \"d1.org\")(NIL NIL \"g2\" \"d2.org\")(NIL NIL NIL NIL)(NIL NIL \"group2\" NIL)(NIL NIL \"g3\" \"d3.org\")(NIL NIL NIL NIL)) NIL NIL NIL NIL)", 1024);
-
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
-
-	dbmail_message_free(message);
-	g_free(result);
-	result = NULL;
-
-	/* bare message with broken From address*/
-	message = dbmail_message_new(NULL);
-	message = dbmail_message_init_with_string(message, broken_message3);
-	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-
-	strncpy(expect,"(\"Fri, 11 Sep 2009 17:42:32 +0100\" \"Re: Anexo II para RO\" ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((\"Foo Bar\" NIL \"foo\" \"bar.pt\")) NIL NIL NIL \"<002001ca32fe$dc7668b0$9600000a@ricardo>\")",1024);
-
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
-
-	dbmail_message_free(message);
-	g_free(result);
-	result = NULL;
-
-	/* message with invalid date*/
-	message = dbmail_message_new(NULL);
-	message = dbmail_message_init_with_string(message, broken_message4);
-	result = imap_get_envelope(GMIME_MESSAGE(message->content));
-
-	// This will intentionally fail until the correct message is evaluated
-	strncpy(expect,"(\"Fri, 11 Sep 2009 17:42:32 +0100\" \"Re: Anexo II para RO\" ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((NIL NIL \"=?iso-8859-1?Q?Bombeiros_Vol._Mort=E1gua?=\" NIL)) ((\"Foo Bar\" NIL \"foo\" \"bar.pt\")) NIL NIL NIL \"<002001ca32fe$dc7668b0$9600000a@ricardo>\")",1024);
-
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed\n[%s] !=\n[%s]\n", result,expect);
+	ck_assert_str_eq(result, expect);
 
 	dbmail_message_free(message);
 	g_free(result);
@@ -422,6 +430,123 @@ START_TEST(test_imap_get_envelope)
 	expect = NULL;
 }
 END_TEST
+
+START_TEST(test_imap_get_envelope_baremessage)
+{
+	DbmailMessage *message;
+	char *result, *expect;
+
+	expect = g_new0(char, 1024);
+
+	/* bare bones message */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, simple);
+	result = imap_get_envelope(GMIME_MESSAGE(message->content));
+
+	strncpy(expect,"(NIL \"dbmail test message\" NIL NIL NIL NIL NIL NIL NIL NIL)", 1024);
+
+	ck_assert_str_eq(result, expect);
+
+	dbmail_message_free(message);
+	g_free(result);
+	result = NULL;
+
+	//
+	g_free(expect);
+	expect = NULL;
+}
+END_TEST
+
+START_TEST(test_imap_get_envelope_groupaddresses)
+{
+	DbmailMessage *message;
+	char *result, *expect;
+
+	expect = g_new0(char, 1024);
+
+	/* text/plain */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, rfc822);
+	result = imap_get_envelope(GMIME_MESSAGE(message->content));
+	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+
+	ck_assert_str_eq(result, expect);
+
+	dbmail_message_free(message);
+	g_free(result);
+	result = NULL;
+
+	/* bare bones message with group addresses*/
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, simple_groups);
+	result = imap_get_envelope(GMIME_MESSAGE(message->content));
+
+	strncpy(expect,"(\"Thu, 15 Feb 2007 01:02:03 +0200\" NIL ((\"Real Name\" NIL \"user\" \"domain\")) ((\"Real Name\" NIL \"user\" \"domain\")) ((\"Real Name\" NIL \"user\" \"domain\")) ((NIL NIL \"group\" NIL)(NIL NIL \"g1\" \"d1.org\")(NIL NIL \"g2\" \"d2.org\")(NIL NIL NIL NIL)(NIL NIL \"group2\" NIL)(NIL NIL \"g3\" \"d3.org\")(NIL NIL NIL NIL)) NIL NIL NIL NIL)", 1024);
+
+	ck_assert_str_eq(result, expect);
+
+	dbmail_message_free(message);
+	g_free(result);
+	result = NULL;
+
+	//
+	g_free(expect);
+	expect = NULL;
+}
+END_TEST
+
+START_TEST(test_imap_get_envelope_brokenfrom)
+{
+	DbmailMessage *message;
+	char *result, *expect;
+
+	expect = g_new0(char, 1024);
+
+	/* bare message with broken From address*/
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, broken_message3);
+	result = imap_get_envelope(GMIME_MESSAGE(message->content));
+
+	strncpy(expect,"(\"Fri, 11 Sep 2009 17:42:32 +0100\" \"Re: Anexo II para RO\" NIL NIL NIL ((\"Foo Bar\" NIL \"foo\" \"bar.pt\")) NIL NIL NIL \"<002001ca32fe$dc7668b0$9600000a@ricardo>\")",1024);
+
+	ck_assert_str_eq(result, expect);
+
+	dbmail_message_free(message);
+	g_free(result);
+	result = NULL;
+
+	//
+	g_free(expect);
+	expect = NULL;
+}
+END_TEST
+
+START_TEST(test_imap_get_envelope_invaliddate)
+{
+	DbmailMessage *message;
+	char *result, *expect;
+
+	expect = g_new0(char, 1024);
+
+	/* message with invalid date*/
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, broken_message4);
+	result = imap_get_envelope(GMIME_MESSAGE(message->content));
+
+	strncpy(expect,"(\"Fri, 3 Jun 202225 20:03:00 +0100\" \"Broken test message 4 with invalid date\" NIL NIL NIL ((\"Foo Bar\" NIL \"foo\" \"bar.pt\")) NIL NIL NIL \"<broken-test-04@p-o.co.uk>\")",1024);
+
+	ck_assert_str_eq(result, expect);
+
+	dbmail_message_free(message);
+	g_free(result);
+	result = NULL;
+
+	//
+	g_free(expect);
+	expect = NULL;
+}
+END_TEST
+
 
 START_TEST(test_imap_get_envelope_8bit_id)
 {
@@ -438,13 +563,13 @@ START_TEST(test_imap_get_envelope_8bit_id)
 	
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
 	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL NIL)",1024);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed");
-	g_free(result);
+	ck_assert_str_eq(result, expect);
 	
 	dbmail_message_set_header(message,"Message-ID","<123123123@foo.bar>");
 	result = imap_get_envelope(GMIME_MESSAGE(message->content));
 	strncpy(expect,"(NIL \"dbmail test message\" ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"somewher\" \"foo.org\")) ((NIL NIL \"testuser\" \"foo.org\")) NIL NIL NIL \"<123123123@foo.bar>\")",1024);
-	fail_unless(strncasecmp(result,expect,1024)==0, "imap_get_envelope failed");
+
+	ck_assert_str_eq(result, expect);
 
 	dbmail_message_free(message);
 	g_free(result);
@@ -506,7 +631,7 @@ END_TEST
 
 START_TEST(test_imap_get_envelope_latin)
 {
-	char *t;
+	char *result;
 	char *expect = g_new0(char,1024);
 	DbmailMessage *m;
 
@@ -514,43 +639,40 @@ START_TEST(test_imap_get_envelope_latin)
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m, encoded_message_latin_1);
 	
-	t = imap_get_envelope(GMIME_MESSAGE(m->content));
-	
-	strncpy(expect,"(NIL \"=?iso-8859-1?Q?Re:_M=F3dulo_Extintores?=\" ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((\"=?iso-8859-1?Q?B=BA_V._F._Z=EAzere?=\" NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
-	
-//	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);
+	result = imap_get_envelope(GMIME_MESSAGE(m->content));
+	strncpy(expect,"(NIL \"Re: Módulo Extintores\" ((\"Bº V. F. Zêzere\" NIL \"nobody\" \"nowhere.org\")) ((\"Bº V. F. Zêzere\" NIL \"nobody\" \"nowhere.org\")) ((\"Bº V. F. Zêzere\" NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	ck_assert_str_eq(result, expect);
 
-	g_free(t);
+	g_free(result);
 	dbmail_message_free(m);
 
 	/*  */
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m, encoded_message_latin_2);
 	
-	strncpy(expect,"(NIL \"=?ISO-8859-2?Q?Re=3A_=5Bgentoo-dev=5D_New_developer=3A__?= =?ISO-8859-2?Q?Miroslav_=A9ulc_=28fordfrog=29?=\" ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav  =?iso-8859-2?b?qXVsYw==?=  (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((NIL NIL \"gentoo-dev\" \"lists.gentoo.org\")) NIL NIL NIL NIL)",1024);
-	t = imap_get_envelope(GMIME_MESSAGE(m->content));
-	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);
+	strncpy(expect,"(NIL \"Re: [gentoo-dev] New developer:  Miroslav Šulc (fordfrog)\" ((\"Miroslav Šulc (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav Šulc (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((\"Miroslav Šulc (fordfrog)\" NIL \"fordfrog\" \"gentoo.org\")) ((NIL NIL \"gentoo-dev\" \"lists.gentoo.org\")) NIL NIL NIL NIL)",1024);
+	result = imap_get_envelope(GMIME_MESSAGE(m->content));
+	ck_assert_str_eq(result, expect);
 	
-	g_free(t);
+	g_free(result);
 	dbmail_message_free(m);
 
 	/*  */
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m, encoded_message_utf8);
 
-	strncpy(expect,"(NIL \"=?utf-8?b?w6nDqcOp?=\" ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	strncpy(expect,"(NIL \"ééé\" ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"nowhere.org\")) ((NIL NIL \"nobody\" \"foo.org\")) NIL NIL NIL NIL)",1024);
+	result = imap_get_envelope(GMIME_MESSAGE(m->content));
+	ck_assert_str_eq(result, expect);
 
-	t = imap_get_envelope(GMIME_MESSAGE(m->content));
-	fail_unless(strcmp(t,expect)==0,"imap_get_envelope failed\n%s\n%s\n ", expect, t);
-	
-	g_free(t);
+	g_free(result);
 	g_free(expect);
 	dbmail_message_free(m);
 }
 END_TEST
 
 
-START_TEST(test_imap_get_partspec)
+START_TEST(test_imap_get_partspec1)
 {
 	DbmailMessage *message;
 	GMimeObject *object;
@@ -562,14 +684,43 @@ START_TEST(test_imap_get_partspec)
 
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"HEADER");
 	result = g_mime_object_to_string(object, NULL);
-	fail_unless(MATCH(rfc822,result),
-			"imap_get_partsec failed \n[%s] !=\n[%s]\n",
-		       	rfc822, result);
-	g_free(result);
+	expect = g_strdup(
+		"Content-Type: text/plain; charset=\"us-ascii\"\n"
+		"MIME-Version: 1.0\n"
+		"Content-Transfer-Encoding: 7bit\n"
+		"Message-Id: <1199706209l.3020l.1l@(none)>\n"
+		"To: testuser@foo.org\n"
+		"From: somewher@foo.org\n"
+		"Subject: dbmail test message\n"
+		"\n"
+		"\n"
+		"    this is a test message\n"
+		"\n"
+	);
 
+	ck_assert_str_eq(result, expect);
+
+	g_free(result);
+	g_free(expect);
+
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec2)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	/* text/plain */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, rfc822);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"HEADER");
 	result = imap_get_logical_part(object,"HEADER");
-	expect = g_strdup("From nobody Wed Sep 14 16:47:48 2005\r\n"
-			"Content-Type: text/plain; charset=\"us-ascii\"\r\n"
+	expect = g_strdup("Content-Type: text/plain; charset=\"us-ascii\"\r\n"
 			"MIME-Version: 1.0\r\n"
 			"Content-Transfer-Encoding: 7bit\r\n"
 			"Message-Id: <1199706209l.3020l.1l@(none)>\r\n"
@@ -578,23 +729,48 @@ START_TEST(test_imap_get_partspec)
 			"Subject: dbmail test message\r\n"
 			"\r\n");
 
-	fail_unless(MATCH(expect,result),"imap_get_partsec failed \n[%s] !=\n[%s]\n", expect, result);
-	g_free(expect);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
+	g_free(expect);
+
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec3)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	/* text/plain */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, rfc822);
 
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"TEXT");
 	result = imap_get_logical_part(object,"TEXT");
 	expect = g_strdup("\r\n"
 			"    this is a test message\r\n"
 			"\r\n");
-	fail_unless(MATCH(expect,result),"imap_get_partsec failed \n[%s] !=\n[%s]\n", expect, result);
-	g_free(expect);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
+	g_free(expect);
 
 	dbmail_message_free(message);
 
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec4)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
 	/* multipart */
-	
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_message);
 
@@ -603,38 +779,95 @@ START_TEST(test_imap_get_partspec)
 	result = imap_get_logical_part(object,"MIME");
 	expect = g_strdup("Content-type: text/html\r\n"
 	        "Content-disposition: inline\r\n\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec5)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	/* multipart */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_message);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1");
 	result = imap_get_logical_part(object,NULL);
 	expect = g_strdup("Test message one\r\n and more.\r\n");
-	fail_unless(MATCH(expect,result),"imap_get_partspec failed:\n[%s] != \n[%s]\n", expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
-	/* object isn't a message/rfc822 so these are 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec6)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	/* object isn't a message/rfc822 so these are
 	 * acually invalid. Let's try anyway */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_message);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1");
 	result = imap_get_logical_part(object,"HEADER");
 	expect = g_strdup("Content-type: text/html\r\n"
 			"Content-disposition: inline\r\n\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec7)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_message);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1");
 	result = imap_get_logical_part(object,"TEXT");
 	expect = g_strdup("Test message one\r\n and more.\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec8)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
 	/* moving on */
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_message);
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"2");
 	result = imap_get_logical_part(object,"MIME");
 	expect = g_strdup(
@@ -642,14 +875,23 @@ START_TEST(test_imap_get_partspec)
 			"Content-transfer-encoding: base64\r\n"
 			"\r\n"
 			);
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
 	dbmail_message_free(message);
-	
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec9)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+	int result2;
+
 	/* multipart mixed */
 	message = dbmail_message_new(NULL);
 	message = dbmail_message_init_with_string(message, multipart_mixed);
@@ -657,31 +899,74 @@ START_TEST(test_imap_get_partspec)
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"2");
 	result = imap_get_logical_part(object,"HEADER");
 	expect = g_strdup("From: \"try\" <try@test.kisise>");
-	fail_unless((strncmp(expect,result,29)==0),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
-	g_free(expect);
-	g_free(result);
+	result2 = strncmp(expect, result, 29);
 
-	object = imap_get_partspec(GMIME_OBJECT(message->content),"2.1.1");
-	result = imap_get_logical_part(object,NULL);
-	expect = g_strdup("Body of doc2\r\n\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-			expect, result);
-	g_free(result);
-	g_free(expect);
-	result = imap_get_logical_part(object,"MIME");
-	expect = g_strdup("Content-Type: text/plain;\r\n"
-			"	charset=\"us-ascii\"\r\n"
-			"Content-Transfer-Encoding: 7bit\r\n\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-			expect, result);
+	ck_assert_int_eq(result2, 0);
+	fail_unless((strncmp(expect,result,29)==0),
+			"imap_get_partspec9 failed:\n[%s] != \n[%s]\n",
+		       	expect, result);
+
 	g_free(result);
 	g_free(expect);
 
 	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec10)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_mixed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"2.1.1");
+	result = imap_get_logical_part(object,NULL);
+
+	expect = g_strdup("Body of doc2\r\n\r\n");
+	ck_assert_str_eq(result, expect);
+
+	g_free(result);
+	g_free(expect);
+
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec11)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_mixed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"2.1.1");
+	result = imap_get_logical_part(object,"MIME");
+
+	expect = g_strdup("Content-Type: text/plain;\r\n"
+			"	charset=\"us-ascii\"\r\n"
+			"Content-Transfer-Encoding: 7bit\r\n\r\n");
+	ck_assert_str_eq(result, expect);
+
+	g_free(result);
+	g_free(expect);
+
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec12)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
 
 	/* multipart signed */
 	message = dbmail_message_new(NULL);
@@ -690,9 +975,24 @@ START_TEST(test_imap_get_partspec)
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.1");
 	result = imap_get_logical_part(object,NULL);
 	expect = g_strdup("quo-pri text");
-	fail_unless(MATCH(expect,result),"imap_get_partspec failed:\n[%s] != \n[%s]\n", expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
+
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec13)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_signed);
 
 	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.3");
 	result = g_mime_object_to_string(object, NULL);
@@ -727,25 +1027,52 @@ START_TEST(test_imap_get_partspec)
 			"\n"
 			"\n");
 
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec14)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_signed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.3");
 	result = imap_get_logical_part(object,"MIME");
 	expect = g_strdup("Content-Type: message/rfc822;\r\n"
 			"Content-Transfer-Encoding: 7bit\r\n"
 			"Content-Disposition: attachment;\r\n"
 			" filename=\"msg1.eml\"\r\n"
 			"\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
-	
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec15)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_signed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.3");
 	result = imap_get_logical_part(object,NULL);
 	expect = g_strdup("Date: Mon, 19 Aug 2013 14:54:05 +0200\r\n"
 			"To: a@b\r\n"
@@ -773,26 +1100,52 @@ START_TEST(test_imap_get_partspec)
 			"\r\n"
 			"\r\n");
 
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
 
+}
+END_TEST
 
+START_TEST(test_imap_get_partspec16)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_signed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.3");
 	result = imap_get_logical_part(object,"MIME");
 	expect = g_strdup("Content-Type: message/rfc822;\r\n"
 			"Content-Transfer-Encoding: 7bit\r\n"
 			"Content-Disposition: attachment;\r\n"
 			" filename=\"msg1.eml\"\r\n"
 			"\r\n");
-	fail_unless(MATCH(expect,result),
-			"imap_get_partspec failed:\n[%s] != \n[%s]\n",
-		       	expect, result);
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
+	dbmail_message_free(message);
+
+}
+END_TEST
+
+START_TEST(test_imap_get_partspec17)
+{
+	DbmailMessage *message;
+	GMimeObject *object;
+	char *result, *expect;
+
+	message = dbmail_message_new(NULL);
+	message = dbmail_message_init_with_string(message, multipart_signed);
+
+	object = imap_get_partspec(GMIME_OBJECT(message->content),"1.3");
 	result = imap_get_logical_part(object,"HEADER");
 	expect = g_strdup("Date: Mon, 19 Aug 2013 14:54:05 +0200\r\n"
 			"To: a@b\r\n"
@@ -803,15 +1156,17 @@ START_TEST(test_imap_get_partspec)
 			"Content-Type: multipart/alternative;\r\n"
 			"\tboundary=b1_7ad0d7cccab59d27194f9ad69c14606001f05f531376916845\r\n"
 			"\r\n");
-				
-	fail_unless(MATCH(expect,result),"imap_get_partspec failed:\n[%s] != \n[%s]\n", expect, result);
+
+	ck_assert_str_eq(result, expect);
+
 	g_free(result);
 	g_free(expect);
 
 	dbmail_message_free(message);
-
 }
 END_TEST
+
+
 
 #if 0
 static uint64_t get_physid(void)
@@ -1063,14 +1418,40 @@ Suite *dbmail_suite(void)
 	
 	tcase_add_checked_fixture(tc_session, setup, teardown);
 	tcase_add_test(tc_session, test_imap_session_new);
-	tcase_add_test(tc_session, test_imap_get_structure);
+	tcase_add_test(tc_session, test_imap_get_structure_bare_bones);
+	tcase_add_test(tc_session, test_imap_get_structure_text_plain);
+	tcase_add_test(tc_session, test_imap_get_structure_multipart);
+	tcase_add_test(tc_session, test_imap_get_structure_multipart_alternative);
+	tcase_add_test(tc_session, test_imap_get_structure_multipart_apple);
+	tcase_add_test(tc_session, test_imap_get_structure_rfc2231);
+	tcase_add_test(tc_session, test_imap_get_structure_multipart_signed);
 	tcase_add_test(tc_session, test_imap_cleanup_address);
 	tcase_add_test(tc_session, test_internet_address_list_parse_string);
 	tcase_add_test(tc_session, test_imap_get_envelope);
+	tcase_add_test(tc_session, test_imap_get_envelope_baremessage);
+	tcase_add_test(tc_session, test_imap_get_envelope_groupaddresses);
+	tcase_add_test(tc_session, test_imap_get_envelope_brokenfrom);
+	tcase_add_test(tc_session, test_imap_get_envelope_invaliddate);
 	tcase_add_test(tc_session, test_imap_get_envelope_8bit_id);
 	tcase_add_test(tc_session, test_imap_get_envelope_koi);
 	tcase_add_test(tc_session, test_imap_get_envelope_latin);
-	tcase_add_test(tc_session, test_imap_get_partspec);
+	tcase_add_test(tc_session, test_imap_get_partspec1);
+	tcase_add_test(tc_session, test_imap_get_partspec2);
+	tcase_add_test(tc_session, test_imap_get_partspec3);
+	tcase_add_test(tc_session, test_imap_get_partspec4);
+	tcase_add_test(tc_session, test_imap_get_partspec5);
+	tcase_add_test(tc_session, test_imap_get_partspec6);
+	tcase_add_test(tc_session, test_imap_get_partspec7);
+	tcase_add_test(tc_session, test_imap_get_partspec8);
+	tcase_add_test(tc_session, test_imap_get_partspec9);
+	tcase_add_test(tc_session, test_imap_get_partspec10);
+	tcase_add_test(tc_session, test_imap_get_partspec11);
+	tcase_add_test(tc_session, test_imap_get_partspec12);
+	tcase_add_test(tc_session, test_imap_get_partspec13);
+	tcase_add_test(tc_session, test_imap_get_partspec14);
+	tcase_add_test(tc_session, test_imap_get_partspec15);
+	tcase_add_test(tc_session, test_imap_get_partspec16);
+	tcase_add_test(tc_session, test_imap_get_partspec17);
 	tcase_add_checked_fixture(tc_util, setup, teardown);
 	tcase_add_test(tc_util, test_dbmail_imap_plist_as_string);
 	tcase_add_test(tc_util, test_dbmail_imap_plist_collapse);
@@ -1090,7 +1471,7 @@ int main(void)
 	g_mime_init();
 	Suite *s = dbmail_suite();
 	SRunner *sr = srunner_create(s);
-	srunner_run_all(sr, CK_NORMAL);
+	srunner_run_all(sr, CK_VERBOSE);
 	nf = srunner_ntests_failed(sr);
 	srunner_free(sr);
 	g_mime_shutdown();

--- a/test/check_dbmail_mailbox.c
+++ b/test/check_dbmail_mailbox.c
@@ -308,7 +308,6 @@ START_TEST(test_dbmail_mailbox_search)
 	size_t size;
 	uint64_t idx = 0;
 	gboolean sorted = 1;
-	int all, found, notfound;
 	DbmailMailbox *mb;
 	Mempool_T pool = mempool_open();
 	
@@ -324,6 +323,19 @@ START_TEST(test_dbmail_mailbox_search)
 	
 	dbmail_mailbox_free(mb);
 	mempool_push(pool, search_keys, size);
+	mempool_close(&pool);
+}
+END_TEST
+
+START_TEST(test_dbmail_mailbox_search2)
+{
+	String_T *search_keys;
+	size_t size;
+	uint64_t idx = 0;
+	int all, found, notfound;
+	gboolean sorted = 1;
+	DbmailMailbox *mb;
+	Mempool_T pool = mempool_open();
 
 	// second case
 	//
@@ -337,8 +349,7 @@ START_TEST(test_dbmail_mailbox_search)
 	all = g_tree_nnodes(mb->found);
 	
 	dbmail_mailbox_free(mb);
-	mempool_push(pool, search_keys, size);
-	
+
 	//
 	idx=0;
 	sorted = 0;
@@ -350,8 +361,7 @@ START_TEST(test_dbmail_mailbox_search)
 	found = g_tree_nnodes(mb->found);
 	
 	dbmail_mailbox_free(mb);
-	mempool_push(pool, search_keys, size);
-	
+
 	//
 	idx=0;
 	sorted = 0;
@@ -363,10 +373,24 @@ START_TEST(test_dbmail_mailbox_search)
 	notfound = g_tree_nnodes(mb->found);
 	
 	dbmail_mailbox_free(mb);
-	mempool_push(pool, search_keys, size);
 
 	fail_unless((all - found) == notfound, "dbmail_mailbox_search failed: SEARCH NOT (all: %d, found: %d, notfound: %d)", all, found, notfound);
-	
+
+	mempool_push(pool, search_keys, size);
+	mempool_close(&pool);
+}
+END_TEST
+
+START_TEST(test_dbmail_mailbox_search3)
+{
+	String_T *search_keys;
+	size_t size;
+	uint64_t idx = 0;
+	gboolean sorted = 1;
+	int found;
+	DbmailMailbox *mb;
+	Mempool_T pool = mempool_open();
+
 	// third case
 	idx=0;
 	sorted = 0;
@@ -393,7 +417,20 @@ START_TEST(test_dbmail_mailbox_search)
 	dbmail_mailbox_free(mb);
 	mempool_push(pool, search_keys, size);
 
-	// 
+	mempool_close(&pool);
+}
+END_TEST
+
+START_TEST(test_dbmail_mailbox_search4)
+{
+	String_T *search_keys;
+	size_t size;
+	uint64_t idx = 0;
+	gboolean sorted = 1;
+	DbmailMailbox *mb;
+	Mempool_T pool = mempool_open();
+
+	//
 	idx=0;
 	sorted = 0;
 	mb = dbmail_mailbox_new(pool, get_mailbox_id("INBOX"));
@@ -619,6 +656,9 @@ Suite *dbmail_mailbox_suite(void)
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_build_imap_search);
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_sort);
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search);
+	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search2);
+	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search3);
+	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search4);
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search_parsed_1);
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_search_parsed_2);
 	tcase_add_test(tc_mailbox, test_dbmail_mailbox_orderedsubject);

--- a/test/check_dbmail_mailboxstate.c
+++ b/test/check_dbmail_mailboxstate.c
@@ -72,17 +72,14 @@ static void insert_message(void)
 
 void setup(void)
 {
-	int result;
 	config_get_file();
 	config_read(configFile);
 	configure_debug(NULL,255,0);
 	GetDBParams();
 	db_connect();
 	auth_connect();
-	result = do_add("mailboxstate1","secretmailboxstate","md5-hash",1024,0,NULL,NULL);
-	ck_assert_uint_eq (result, TRUE);
-	result = do_add("mailboxstate2","secretmailboxstate","md5-hash",0,0,NULL,NULL);
-	ck_assert_uint_eq (result, TRUE);
+	do_add("mailboxstate1","secretmailboxstate","md5-hash",1024,0,NULL,NULL);
+	do_add("mailboxstate2","secretmailboxstate","md5-hash",0,0,NULL,NULL);
 	testboxid = get_mailbox_id("mailboxstate1", TESTBOX);
 }
 

--- a/test/check_dbmail_mailboxstate.c
+++ b/test/check_dbmail_mailboxstate.c
@@ -51,7 +51,9 @@ static uint64_t get_mailbox_id(const char *username, const char *boxname)
 {
 	uint64_t id;
 	auth_user_exists(username, &testuserid);
+	ck_assert_uint_gt (testuserid, 0);
 	db_find_create_mailbox(boxname, BOX_COMMANDLINE, testuserid, &id);
+	ck_assert_uint_gt (id, 0);
 	return id;
 }
 
@@ -94,7 +96,7 @@ START_TEST(test_metadata)
 {
 	// Test user who goes over quota
 	testuserid = 4;
-	testboxid = get_mailbox_id("testuser1", TESTBOX);
+	testboxid = get_mailbox_id("testuser1", "metadata");
 	MailboxState_T M = MailboxState_new(NULL, testboxid);
 	ck_assert_uint_eq (MailboxState_getUnseen(M), 0);
 	ck_assert_uint_eq (MailboxState_getRecent(M), 0);
@@ -111,22 +113,22 @@ START_TEST(test_metadata)
 
 	// Test user below quota
 	testuserid = 5;
-	testboxid = get_mailbox_id("testuser2", TESTBOX);
+	testboxid = get_mailbox_id("testuser2", "metadata");
 	ck_assert_uint_gt (testboxid, 0);
 
 	M = MailboxState_new(NULL, testboxid);
 	MailboxState_count(M);
-	ck_assert_uint_eq (MailboxState_getUnseen(M), 2);
-	ck_assert_uint_eq (MailboxState_getRecent(M), 2);
-	ck_assert_uint_eq (MailboxState_getExists(M), 2);
+	ck_assert_uint_eq (MailboxState_getUnseen(M), 0);
+	ck_assert_uint_eq (MailboxState_getRecent(M), 0);
+	ck_assert_uint_eq (MailboxState_getExists(M), 0);
 
 	insert_message();
 
 	MailboxState_count(M);
 
-	ck_assert_uint_eq (MailboxState_getUnseen(M), 3);
-	ck_assert_uint_eq (MailboxState_getRecent(M), 3);
-	ck_assert_uint_eq (MailboxState_getExists(M), 3);
+	ck_assert_uint_eq (MailboxState_getUnseen(M), 1);
+	ck_assert_uint_eq (MailboxState_getRecent(M), 1);
+	ck_assert_uint_eq (MailboxState_getExists(M), 1);
 	MailboxState_free(&M);
 
 	// Revert user and mailbox

--- a/test/check_dbmail_message.c
+++ b/test/check_dbmail_message.c
@@ -111,26 +111,8 @@ START_TEST(test_dbmail_message_get_class)
 	dbmail_message_free(m);
 }
 END_TEST
-static char * showdiff(const char *a, const char *b)
-{
-	assert(a && b);
-	while (*a++ == *b++)
-		;
-	return g_strdup_printf("[%s]\n[%s]\n", --a, --b);
-}
 
 FILE *i;
-#define COMPARE(a,b) \
-	{ \
-	int d; size_t l; char *s;\
-	l = strlen(a); \
-	d = memcmp((a),(b),l); \
-	if (d) { \
-		s = showdiff(a,b); \
-		fail_unless(d == 0, "store store/retrieve failed\n%s\n\n", s); \
-		g_free(s); \
-	} \
-	}
 
 static DbmailMessage  * message_init(const char *message)
 {
@@ -179,7 +161,7 @@ START_TEST(test_g_mime_object_get_body)
 	
 	m = message_init(rfc822);
 	result = g_mime_object_get_body(GMIME_OBJECT(m->content));
-	COMPARE("\n    this is a test message\n\n", result);
+	ck_assert_str_eq("\n    this is a test message\n\n", result);
 	g_free(result);
 	dbmail_message_free(m);
 }
@@ -194,253 +176,299 @@ START_TEST(test_dbmail_message_store)
 	m = message_init("From: paul\n");
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	fail_unless(MATCH(e,t),"test_dbmail_message_store failed\n%s\n%s", e, t);
-	COMPARE(e,t);
+
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(simple);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	printf("%s %s",e,t);
-	COMPARE(e,t);
-	COMPARE(simple, t);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(rfc822);
 	e = dbmail_message_to_string(m);
+
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(rfc822, t);
+	// trim junk from rfc822
+	strncpy(e, rfc822+37, strlen(rfc822)-37);
+	m = message_init(e);
+	e = dbmail_message_to_string(m);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message2);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message2, t);
+	ck_assert_str_eq(e, t);
+	// trim junk from multipart_message2
+	strncpy(e, multipart_message2+56, strlen(multipart_message2)-56);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(message_rfc822);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(message_rfc822, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(message_rfc822, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message3);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message3, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message3, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message4);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message4, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message4, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message5);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message5, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message5, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message6);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	//COMPARE(multipart_message6, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message6, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message7);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message7, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message8);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
+	ck_assert_str_eq(multipart_message8, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message9);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message9, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_mixed);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_mixed, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_mixed, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(broken_message);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	//COMPARE(e,t);
-	//COMPARE(broken_message, t);
+	// remove non message preamble
+	strncpy(e, broken_message+42, strlen(broken_message)-42);
+	// add closing boundary
+	strcat(e, "--=-i5BOOWGh5HearcweMC39--\n");
+	ck_assert_str_eq(e, t);
+	// broken message is fixed so not equal
+	// ck_assert_str_eq(broken_message, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_latin_1);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_latin_1, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_latin_1, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_latin_2);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_latin_2, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_latin_2, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_utf8);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_utf8, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_utf8, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_utf8_1);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_utf8_1, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_utf8_1, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_utf8_2);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_utf8_2, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_utf8_2, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(encoded_message_koi);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(encoded_message_koi, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(encoded_message_koi, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(raw_message_koi);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(raw_message_koi, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(raw_message_koi, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_alternative);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_alternative, t);
+	ck_assert_str_eq(e, t);
+	// remove non message preamble
+	strncpy(e, multipart_alternative+42, strlen(multipart_alternative)-42);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(outlook_multipart);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	// COMPARE(e,t);
-	// COMPARE(outlook_multipart, t);
+	ck_assert_str_eq(e, t);
+	strncpy(e, outlook_multipart+65, strlen(outlook_multipart)-65);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_alternative2);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_alternative2, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_alternative2, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_apple);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_apple, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_apple, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(long_quopri_subject);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(long_quopri_subject, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(long_quopri_subject, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message_big);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message_big, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message_big, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_digest);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	//COMPARE(e,t);
-	//COMPARE(multipart_digest, t);
+	// TODO
+	//ck_assert_str_eq(e, t);
+	//ck_assert_str_eq(multipart_digest, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_alternative3);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_alternative3, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_alternative3, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_signed);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
+	ck_assert_str_eq(e, t);
 	g_free(e);
 	g_free(t);
+
 	//-----------------------------------------
 	m = message_init(multipart_message_submessage);
 	e = dbmail_message_to_string(m);
 	t = store_and_retrieve(m);
-	COMPARE(e,t);
-	COMPARE(multipart_message_submessage, t);
+	ck_assert_str_eq(e, t);
+	ck_assert_str_eq(multipart_message_submessage, t);
 	g_free(e);
 	g_free(t);
 }
@@ -471,7 +499,7 @@ START_TEST(test_dbmail_message_store2)
 	
 	t = dbmail_message_to_string(n);
 	
-	COMPARE(expect,t);
+	ck_assert_str_eq(expect,t);
 	
 	dbmail_message_free(n);
 	g_free(expect);
@@ -573,7 +601,7 @@ START_TEST(test_dbmail_message_get_internal_date)
 
 	char *before = dbmail_message_to_string(m);
 	char *after = store_and_retrieve(m);
-	COMPARE(before, after);
+	ck_assert_str_eq(before, after);
 	g_free(before);
 	g_free(after);
 }
@@ -581,27 +609,29 @@ END_TEST
 
 START_TEST(test_dbmail_message_to_string)
 {
-        char *result;
+	char *result;
+	char *expect;
 	DbmailMessage *m;
-        
+
 	m = message_init(multipart_message);
-        result = dbmail_message_to_string(m);
-	COMPARE(multipart_message, result);
+	result = dbmail_message_to_string(m);
+	ck_assert_str_eq(multipart_message, result);
 	g_free(result);
 	dbmail_message_free(m);
 
-	//
+	// remove non message preamble
+	expect = malloc(sizeof(char) * 4096);
+	strncpy(expect, simple_with_from+52, strlen(simple_with_from)-52);
+
 	m = message_init(simple_with_from);
 	result = dbmail_message_to_string(m);
-	COMPARE(simple_with_from, result);
+	ck_assert_str_eq(expect, result);
 	g_free(result);
+	g_free(expect);
 	dbmail_message_free(m);
-
 }
 END_TEST
     
-//gchar * dbmail_message_hdrs_to_string(DbmailMessage *self);
-
 START_TEST(test_dbmail_message_hdrs_to_string)
 {
 	char *result;
@@ -725,12 +755,12 @@ END_TEST
 START_TEST(test_dbmail_message_encoded)
 {
 	DbmailMessage *m = dbmail_message_new(NULL);
-	//const char *exp = ":: [ Arrty ] :: [ Roy (L) St�phanie ]  <over.there@hotmail.com>";
 	uint64_t id = 0;
 
 	m = dbmail_message_init_with_string(m, encoded_message_koi);
-	fail_unless(strcmp(dbmail_message_get_header(m,"From"),"=?koi8-r?Q?=E1=CE=D4=CF=CE=20=EE=C5=C8=CF=D2=CF=DB=C9=C8=20?=<bad@foo.ru>")==0, 
-			"dbmail_message_get_header failed for koi-8 encoded header");
+
+	ck_assert_str_eq(dbmail_message_get_header(m,"From"),"Антон Нехороших <bad@foo.ru>");
+
 	dbmail_message_free(m);
 
 	m = dbmail_message_new(NULL);
@@ -839,20 +869,22 @@ START_TEST(test_dbmail_message_construct)
 	const gchar *subject = "Some test";
 	const gchar *recipient = "<bar@foo.org> Bar";
 	gchar *body = g_strdup("testing\nține un gând");
-	gchar *expect = g_strdup("From: foo@bar.org\n"
-	"Subject: Some test\n"
-	"To: bar@foo.org\n"
+	gchar *expect = g_strdup("Subject: Some test\n"
+	"Sender: foo@bar.org\n"
+	"To: <bar@foo.org> Bar\n"
 	"MIME-Version: 1.0\n"
 	"Content-Type: text/plain; charset=utf-8\n"
 	"Content-Transfer-Encoding: base64\n"
 	"\n"
-	"dGVzdGluZwrIm2luZSB1biBnw6Ju");
+	"dGVzdGluZwrIm2luZSB1biBnw6Ju\n");
 	gchar *result;
 
 	DbmailMessage *message = dbmail_message_new(NULL);
 	message = dbmail_message_construct(message,recipient,sender,subject,body);
 	result = dbmail_message_to_string(message);
-	fail_unless(MATCH(expect,result),"dbmail_message_construct failed \nExpect:<<%s>>\nResult:<<%s>>", expect, result);
+
+	ck_assert_str_eq(expect, result);
+
 	dbmail_message_free(message);
 	g_free(body);
 	g_free(result);
@@ -892,12 +924,13 @@ START_TEST(test_dbmail_message_get_size)
 	m = dbmail_message_init_with_string(m, rfc822);
 
 	i = dbmail_message_get_size(m, FALSE);
-	fail_unless(i==277, "dbmail_message_get_size failed [%zu]", i);
+	ck_assert_uint_eq (i, 277);
+	//fail_unless(i==251, "dbmail_message_get_size failed [%zu]", i);
 	j = dbmail_message_get_size(m, TRUE);
-	fail_unless(j==289, "dbmail_message_get_size failed [%zu]", j);
+	ck_assert_uint_eq (j, 251);
+	//fail_unless(j==289, "dbmail_message_get_size failed [%zu]", j);
 
 	dbmail_message_free(m);
-	return;
 
 	/* */
 	m = dbmail_message_new(NULL);
@@ -990,8 +1023,8 @@ START_TEST(test_dbmail_message_utf8_headers)
 	char *s_dec,*t = NULL;
 	const char *utf8_invalid_fixed = "=?UTF-8?B?0J/RgNC40LPQu9Cw0YjQsNC10Lwg0L3QsCDRgdC10YA/IA==?= =?UTF-8?B?0LrQvtC90LXRhiDRgdGC0YDQvtC60Lg=?=";
 
-        m = dbmail_message_new(NULL);
-        m = dbmail_message_init_with_string(m,utf8_long_header);
+	m = dbmail_message_new(NULL);
+	m = dbmail_message_init_with_string(m,utf8_long_header);
 	dbmail_message_store(m);
 	physid = dbmail_message_get_physid(m);
 
@@ -999,12 +1032,10 @@ START_TEST(test_dbmail_message_utf8_headers)
 	s_dec = g_mime_utils_header_decode_phrase(NULL, s);
 	test_db_get_subject(physid,&t);
 
-        fail_unless(MATCH(s_dec,t), "[%" PRIu64 "] utf8 long header failed:\n[%s] !=\n[%s]\n", 
-			physid, s_dec, t);
+	ck_assert_str_eq (s_dec,t);
 
 	dbmail_message_free(m);
 	g_free(s_dec);
-	//
 
 	m = dbmail_message_new(NULL);
 	m = dbmail_message_init_with_string(m,utf8_invalid);


### PR DESCRIPTION
The upgrade to gmime version 3 was implemented at pace to ensure dbmail continued after the removal of version 2. These patches finish the upgrade and all tests now pass.

GMime improves message processing so there are a number of changes including mime examples amended to fix errors and omissions where appropriate. Output is now utf-8 so the expected output is amended where necessary. The latest version of check introduced new macros to make testing easier and  ck_assert_str_eq replaces COMPARE.

There is a bug in how multipart_digest is processed and a separate issue has been raised #324.

Although passing, these tests should probably be refactored for consistency.