### PR TITLE
added messageblks in MySQL create_tables.sql

### DIFF
--- a/sql/mysql/create_tables.mysql
+++ b/sql/mysql/create_tables.mysql
@@ -298,6 +298,25 @@ CREATE TABLE `dbmail_physmessage` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --
+-- Table structure for table `dbmail_messageblks`
+--
+
+CREATE TABLE dbmail_messageblks (
+    messageblk_idnr BIGINT AUTO_INCREMENT PRIMARY KEY,
+    physmessage_id BIGINT(20) unsigned,
+    messageblk LONGBLOB NOT NULL,
+    blocksize BIGINT DEFAULT 0 NOT NULL,
+    is_header SMALLINT DEFAULT 0 NOT NULL,
+    FOREIGN KEY (physmessage_id) REFERENCES dbmail_physmessage(id)
+        ON DELETE CASCADE ON UPDATE CASCADE
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE INDEX dbmail_messageblks_physmessage_idx
+    ON dbmail_messageblks(physmessage_id);
+
+CREATE INDEX dbmail_messageblks_physmessage_is_header_idx
+    ON dbmail_messageblks(physmessage_id, is_header);
+--
 -- Table structure for table `dbmail_referencesfield`
 --
 


### PR DESCRIPTION
I realized on an old server of ours that this table was missing so I tried to figure out why.

I couldn't find it in the MySQL `create_tables.sql` script so I copied it from the PostgreSQL and modified it as needed to create the table in an existing DBmail database.

