### PR TITLE
Duplicate envelope inserts now treated as warnings

### DIFF
--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1980,9 +1980,9 @@ void dbmail_message_cache_envelope(const DbmailMessage *self)
 		db_stmt_exec(s);
 		db_commit_transaction(c);
 	CATCH(SQLException)
-		LOG_SQLERROR;
+		LOG_SQLWARNING;
 		db_rollback_transaction(c);
-		TRACE(TRACE_ERR, "insert envelope failed [%s]", envelope);
+		TRACE(TRACE_WARNING, "insert envelope failed [%s]", envelope);
 	FINALLY
 		db_con_close(c);
 	END_TRY;


### PR DESCRIPTION
Envelope caching can have failed duplicate inserts, these create noise rather than indicate an error and this patch reduces them to warnings. Part of #333