### PR TITLE
Update RPM spec files for dbmail, libsieve and libzdb

### DIFF
--- a/contrib/build-centos-rpm/dbmail.spec
+++ b/contrib/build-centos-rpm/dbmail.spec
@@ -1,6 +1,6 @@
 %define         services dbmail-imapd dbmail-pop3d dbmail-lmtpd dbmail-timsieved
 
-%define		SRCBASE	%{_builddir}/%{name}-%{version}
+%define		SRCBASE	%{_builddir}/%{name}-main
 %define		TMPLIB	%{buildroot}/usr/lib/tmpfiles.d
 %define		SOURCE1	%{SRCBASE}/systemd/dbmail-imapd.service
 %define		SOURCE2 %{SRCBASE}/systemd/dbmail-pop3d.service
@@ -9,11 +9,11 @@
 %define		SOURCE5	%{SRCBASE}/dbmail.cron
 %define		SOURCE6	%{SRCBASE}/dbmail.logrotate
 %define		SOURCE7	%{SRCBASE}/dbmail.sysconfig
-%define         SOURCE8 %{SRCBASE}/README
+%define   SOURCE8 %{SRCBASE}/README
 %define		SOURCE9	%{SRCBASE}/dbmail.conf
 
 Name:           dbmail
-Version:        3.2.5
+Version:        3.5.0
 Release:        2%{?dist}
 Summary:        A database backed mail storage system
 
@@ -21,7 +21,7 @@ Group:          System Environment/Daemons
 # db_getopot.c is licensed MIT
 License:        GPLv2+ and MIT
 URL:            http://www.dbmail.org
-Source0:        dbmail-3.2.5.tar.gz
+Source0:        https://github.com/dbmail/dbmail/archive/refs/heads/main.zip
 
 #Patch0:         dbmail-3.0.2-gthread.patch
 
@@ -71,7 +71,7 @@ Please see /usr/share/doc/dbmail-*/README.fedora for specific information on
 installation and configuration in Fedora.
 
 %prep
-%setup -q
+%setup -q -n %{name}-main
 
 %if 0%{?rhel} && 0%{?rhel} > 5
 # Temporary patch - gmime is not adding flags for gthread; add to
@@ -95,7 +95,7 @@ sed -i -e 's,\(^db\W*=\)\(.*$\),\1 %{_localstatedir}/lib/dbmail/dbmail.db,'   \
        -e 's/\(^EFFECTIVE_GROUP\W*=\)\(.*$\)/\1 dbmail/' dbmail.conf
 
 %if 0%{?fedora} && 0%{?fedora} > 13
-sed -i 's/gmime-2.4/gmime-2.6/g' configure
+#sed -i 's/gmime-2.4/gmime-2.6/g' configure
 %endif
 
 %build

--- a/contrib/build-centos-rpm/libsieve.spec
+++ b/contrib/build-centos-rpm/libsieve.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package libsieve (Version 2.2.7)
+# spec file for package libsieve (Version 2.2)
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -11,7 +11,7 @@
 # published by the Open Source Initiative.
 
 Name:           libsieve
-Version:        2.2.7
+Version:        2.2
 Release:        2%{?dist}
 Summary:        A Library for Parsing, Sorting and Filtering Your Mail
 
@@ -20,7 +20,7 @@ Group:          Development/Libraries/Other
 # more restrictive GPL tag for the license
 License:        GPL
 URL:            https://github.com/sodabrew/libsieve
-Source0:        https://github.com/downloads/sodabrew/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/sodabrew/libsieve/archive/libsieve-2.2.zip
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  flex bison pkgconfig libtool
 
@@ -47,11 +47,10 @@ emails. The rest is up to you!
 
 
 %prep 
-%setup -q
+%setup -q -n %{name}-%{name}-%{version}/src
 
 %build 
-libtoolize --copy --force
-autoreconf --force --install --symlink
+./bootstrap
 %configure 
 make %{?_smp_mflags}
 
@@ -70,7 +69,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root,-) 
 %{_libdir}/*.so.*
-%doc AUTHORS COPYING NEWS README
+%doc ../AUTHORS ../COPYING ../NEWS ../README
 
 %package devel
 Summary: A Library for Parsing, Sorting and Filtering Your Mail

--- a/contrib/build-centos-rpm/libsieve.spec
+++ b/contrib/build-centos-rpm/libsieve.spec
@@ -20,7 +20,7 @@ Group:          Development/Libraries/Other
 # more restrictive GPL tag for the license
 License:        GPL
 URL:            https://github.com/sodabrew/libsieve
-Source0:        https://github.com/sodabrew/libsieve/archive/libsieve-2.2.zip
+Source0:        https://github.com/sodabrew/libsieve/archive/%{name}-%{version}.zip
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  flex bison pkgconfig libtool
 

--- a/contrib/build-centos-rpm/libzdb.spec
+++ b/contrib/build-centos-rpm/libzdb.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package libzdb (Version 3.1)
+# spec file for package libzdb (Version 3.4.0)
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/contrib/build-centos-rpm/libzdb.spec
+++ b/contrib/build-centos-rpm/libzdb.spec
@@ -11,7 +11,7 @@
 # published by the Open Source Initiative.
 
 Name:           libzdb
-Version:        3.1
+Version:        3.4.0
 Release:        2%{?dist}
 Summary:        The Zild C Database Library implements a small, fast, and easy to  use database API
 
@@ -20,9 +20,9 @@ Group:          Development/Libraries/Database
 # more restrictive GPL tag for the license
 License:        GPL
 URL:            https://github.com/mverbert/libzdb
-Source0:        https://github.com/downloads/libzdb/%{name}/%{name}-%{version}.tar.gz
+Source0:        https://www.tildeslash.com/libzdb/dist/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  flex bison mariadb-devel openssl-devel postgresql-devel pkgconfig libtool
+BuildRequires:  flex bison mariadb-devel openssl-devel postgresql-devel pkgconfig libtool autoconf-archive
 
 %description
     The Zild C Database Library implements a small, fast, and easy to
@@ -36,8 +36,6 @@ BuildRequires:  flex bison mariadb-devel openssl-devel postgresql-devel pkgconfi
 %setup -q
 
 %build 
-libtoolize --copy --force
-autoreconf --force --install --symlink
 %configure 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
Changes made to RPM spec files:

dbmail.spec:
- Update version to 3.5.0
- Update source URL to use GitHub main branch
- Fix source directory path for main branch
- Comment out deprecated gmime patch

libsieve.spec:
- Update version to 2.2
- Update source URL to use GitHub archive
- Fix source directory path for archive structure 
- Update build process to use bootstrap script
- Fix documentation path

libzdb.spec:
- Update version to 3.4.0
- Update source URL to use tildeslash.com
- Add autoconf-archive build dependency
- Remove manual libtoolize/autoreconf steps

All changes tested and verified to build successfully.