### PR TITLE
Feature forward email override sender

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -85,6 +85,17 @@ sendmail              = /usr/sbin/sendmail
 # smtp_user
 # smtp_password
 
+# 
+# Allows to override sender when forwards are made (based dbmail_alias table)
+# Works for both authsql and authldap.
+# Bounces are never forwarded in order to prevent denial of service
+#
+# 0 = no forward override, it preserves the original sender.
+# 1 = all forwards have the sender changed to the actual alias
+# 2 = allows a finner degree of control by specifing which aliases can have their sender changed or not. When using authldap, 
+#		the control is based on information written in dbmail_alias table, by switching on/off the override_fw_sender
+#
+forward_sender_override	   = 0
 #
 #
 # The following items can be overridden in the service-specific sections.

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -89,7 +89,8 @@ sendmail              = /usr/sbin/sendmail
 # Allows to override sender when forwards are made (based dbmail_alias table)
 # Works for both authsql and authldap.
 # Bounces are never forwarded in order to prevent denial of service
-#
+# Note: this is experimental, use with care!
+# 
 # 0 = no forward override, it preserves the original sender.
 # 1 = all forwards have the sender changed to the actual alias
 # 2 = allows a finner degree of control by specifing which aliases can have their sender changed or not. When using authldap, 

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -93,7 +93,7 @@ sendmail              = /usr/sbin/sendmail
 # 
 # 0 = no forward override, it preserves the original sender.
 # 1 = all forwards have the sender changed to the actual alias
-# 2 = allows a finner degree of control by specifing which aliases can have their sender changed or not. When using authldap, 
+# 2 = allows a finer degree of control by specifying which aliases can have their sender changed or not. When using authldap, 
 #		the control is based on information written in dbmail_alias table, by switching on/off the override_fw_sender
 #
 forward_sender_override	   = 0

--- a/sql/mysql/upgrades/35001.mysql
+++ b/sql/mysql/upgrades/35001.mysql
@@ -25,6 +25,7 @@ ALTER TABLE `dbmail_upgrade_steps` CONVERT TO CHARACTER SET utf8mb4;
 ALTER TABLE `dbmail_usermap` CONVERT TO CHARACTER SET utf8mb4;
 ALTER TABLE `dbmail_users` CONVERT TO CHARACTER SET utf8mb4;
 
+
 INSERT INTO dbmail_upgrade_steps (from_version, to_version, applied) values (32006, 35001, now());
 
 COMMIT;

--- a/sql/postgresql/upgrades/35001.psql
+++ b/sql/postgresql/upgrades/35001.psql
@@ -1,6 +1,9 @@
 BEGIN;
 
+ALTER TABLE `dbmail_aliases` ADD COLUMN `override_fw_sender` int UNSIGNED NOT NULL DEFAULT '0';
+
 -- noop as mysql upgrade only
+
 INSERT INTO dbmail_upgrade_steps (from_version, to_version, applied) values (32006, 35001, now());
 
 COMMIT;

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -163,7 +163,6 @@ typedef struct {
 	int part_key;
 	int part_depth;
 	int part_order;
-
 } DbmailMessage;
 
 /**********************************************************************

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -163,6 +163,13 @@ typedef struct {
 	int part_key;
 	int part_depth;
 	int part_order;
+
+	
+	//flag: nessages that contain certain types of parts
+	//- message/delivery-status
+	//- multipart/report
+	//0 = normal, 1 = delivery report
+	int message_type;
 } DbmailMessage;
 
 /**********************************************************************

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -252,8 +252,8 @@ int config_get_value_default_int(const Field_T field_name,
 					int default_value){
 	Field_T value;
 	int result_fetch = config_get_value(field_name, service_name, value);
-	int result=default_value;
-	if (result_fetch==0){
+	int result = default_value;
+	if (result_fetch == 0){
 		/* no error */
 		result=atoi(value);
 	}

--- a/src/dm_db.h
+++ b/src/dm_db.h
@@ -228,7 +228,10 @@ void mailbox_match_free(struct mailbox_match *m);
  * -  1 on table found
  */
 int db_use_usermap(void);
-
+/**
+ * Check if we can perform forward sender override
+ */
+int dm_check_forward_override(const char *from, const char *to);
 /**
  * \brief check if username exists in the usermap table
  * \param int tx filehandle of connected client

--- a/src/dm_dsn.c
+++ b/src/dm_dsn.c
@@ -217,6 +217,11 @@ void dsnuser_free(Delivery_T * dsnuser)
 	if (dsnuser->forwards) {
 		dsnuser->forwards = g_list_first(dsnuser->forwards);
 		while(dsnuser->forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)(dsnuser->forwards->data);
+			g_free(pair->from);
+			pair->from = NULL;
+			g_free(pair->to);
+			pair->to = NULL;
 			g_free(dsnuser->forwards->data);
 			dsnuser->forwards = g_list_next(dsnuser->forwards);
 		}

--- a/src/dm_dsn.h
+++ b/src/dm_dsn.h
@@ -39,13 +39,20 @@ typedef struct {
 	int detail;
 } delivery_status_t;
 
+//structure of the forward override sender
+typedef struct {
+	char *from;
+	char *to;
+	uint64_t override_fw_sender;
+} DeliveryItem_T;
+
 typedef struct {
 	uint64_t useridnr;		/* Specific user id recipient (from outside). */
 	char *address;	/* Envelope recipient (from outside). */
 	char *mailbox;	/* Default mailbox to use for userid deliveries (from outside). */
 	mailbox_source source; /* Who specified the mailbox (e.g. trusted or untrusted source)? */
 	GList *userids;	/* List of uint64_t* -- internal useridnr's to deliver to (internal). */
-	GList *forwards;	/* List of char* -- external addresses to forward to (internal). */
+	GList *forwards;	/* List of DeliveryItem_T -- external addresses to forward to (internal). */
 	delivery_status_t dsn;	/* Return status of this "delivery basket" (to outside). */
 } Delivery_T;
 

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -978,6 +978,8 @@ const char * dbmail_message_get_envelope_recipient(const DbmailMessage *self)
 
 void dbmail_message_set_header(DbmailMessage *self, const char *header, const char *value)
 {
+	//remove first and then add
+	g_mime_object_remove_header(GMIME_OBJECT(self->content), header);
 	g_mime_object_prepend_header(GMIME_OBJECT(self->content), header, value, self->charset);
 }
 
@@ -2619,7 +2621,7 @@ int send_mail(DbmailMessage *message,
 		// fall-through
 	case SENDMESSAGE:
 		buf = dbmail_message_to_string(message);
-		TRACE(TRACE_DEBUG, "Sending message:\n%s\n",buf);
+		TRACE(TRACE_INFO, "Sending message:\n%s\n",buf);
 		fprintf(mailpipe, "%s", buf);
 		g_free(buf);
 		break;

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -2943,20 +2943,20 @@ int send_forward_list(DbmailMessage *message, GList *targets, const char *from)
 					//this is a normal message(not a bounce), evaluate the need to change from source
 					if (dm_check_forward_override(from_local,to)>0){
 						if (from_local){
-							TRACE(TRACE_ERR, "forwarding normal message by changing %s to %s", from, from_local);
+							TRACE(TRACE_NOTICE, "forwarding normal message to %s, from %s (changed from %s)", to, from_local, from);
 							result |= send_mail(message, to, from_local, NULL, SENDRAW, SENDMAIL);
 						}else{
-							TRACE(TRACE_ERR, "forwarding normal message to default from %s due to null from", from);
-							result |= send_mail(message, to, from_local, NULL, SENDRAW, SENDMAIL);
+							TRACE(TRACE_NOTICE, "forwarding normal message to %s from %s (due to null)", to, from);
+							result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
 						}
 					}else{
-						TRACE(TRACE_ERR, "forwarding normal message to %s, not changing to %s", from, from_local);
+						TRACE(TRACE_NOTICE, "forwarding normal message to %s, from %s (not changing due to policy) ", to, from);
 						result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
 					}
 				}else{
 					// The forward is an email address.
-					TRACE(TRACE_ERR, "forwarding bounce message to %s,  not changing to %s", from, from_local);
-					result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
+					TRACE(TRACE_NOTICE, "forwarding bounce message to %s, stopped (due to policy) ",to);
+					//result |= send_mail(message, to, from, NULL, SENDRAW, SENDMAIL);
 				}
 			}
 		}

--- a/src/dm_user.c
+++ b/src/dm_user.c
@@ -680,16 +680,40 @@ static int show_alias(const char * const name, int concise)
 	}
 
 	if (forwards) {
+		GList *fwd=NULL;
+		while (forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)forwards->data;
+			//char *from_local=pair->from;
+			char *to=g_strdup(pair->to);
+			fwd = g_list_prepend(fwd, to);
+			if (! g_list_next(forwards))
+				break;
+			forwards = g_list_next(forwards);
+		}
+		GString *fwdlist = g_list_join(fwd,",");
 		if (concise) {
-			GString *fwdlist = g_list_join(forwards,",");
+			//GString *fwdlist = g_list_join(forwards,",");
 			printf("%s: %s\n", name, fwdlist->str);
-			g_string_free(fwdlist, TRUE);
+			//g_string_free(fwdlist, TRUE);
 		} else {
-			GString *fwdlist = g_list_join(forwards,", ");
+			//GString *fwdlist = g_list_join(forwards,", ");
 			printf("forward [%s] to [%s]\n", name, fwdlist->str);
-			g_string_free(fwdlist, TRUE);
+			//g_string_free(fwdlist, TRUE);
+		}
+		g_string_free(fwdlist, TRUE);
+
+		while(forwards) {
+			DeliveryItem_T *pair = (DeliveryItem_T *)(forwards)->data;
+			g_free(pair->from);
+			pair->from = NULL;
+			g_free(pair->to);
+			pair->to = NULL;
+			if (! g_list_next(forwards)) break;
+			forwards = g_list_next(forwards);
 		}
 		g_list_destroy(g_list_first(forwards));
+		//g_list_destroy(g_list_first(forwards));
+		g_list_destroy(fwd);
 	}
 	
 	userids = g_list_first(userids);

--- a/src/modules/authldap.c
+++ b/src/modules/authldap.c
@@ -972,7 +972,7 @@ int auth_check_user_ext(const char *address, GList **userids, GList **fwds, int 
 				if (id == 0) {
 					//add only is not an integer (which is actually a mailbox)
 					DeliveryItem_T *item = g_new0(DeliveryItem_T,1);
-					item->from = g_strdup(username);
+					item->from = g_strdup(address);
 					item->to = g_strdup(attrvalue);
 					*(GList **)fwds = g_list_prepend(*(GList **)fwds, item);
 				}

--- a/src/modules/authsql.c
+++ b/src/modules/authsql.c
@@ -227,8 +227,9 @@ int auth_check_user_ext(const char *username, GList **userids, GList **fwds, int
 				TRACE(TRACE_DEBUG, "user [%s] is not active", username);
 			}
 		} else {
-			*(GList **)fwds = g_list_prepend(*(GList **)fwds, g_strdup(username));
-			TRACE(TRACE_DEBUG, "adding [%s] to deliver_to address occurences [%d]", username, occurences);
+			//do not do anything
+			//*(GList **)fwds = g_list_prepend(*(GList **)fwds, g_strdup(username));
+			//TRACE(TRACE_DEBUG, "adding [%s] to deliver_to address occurences [%d]", username, occurences);
 		}
 		return occurences;
 	} 
@@ -237,9 +238,18 @@ int auth_check_user_ext(const char *username, GList **userids, GList **fwds, int
 		/* do a recursive search for deliver_to */
 		char *deliver_to = (char *)d->data;
 		TRACE(TRACE_DEBUG, "checking user %s to %s", username, deliver_to);
-		
 		occurences += auth_check_user_ext(deliver_to, userids, fwds, checks+1);
-
+		TRACE(TRACE_DEBUG, "checking(2) user %s to %s", username, deliver_to);
+		id = strtoull(deliver_to, &endptr, 10);
+		if (id == 0) {
+			//add only is not an integer (which is actually a mailbox)
+			DeliveryItem_T *item = g_new0(DeliveryItem_T,1);
+			TRACE(TRACE_DEBUG, "adding [%s] to deliver_to %s, occurences [%d]", username, deliver_to, occurences);
+			//should add to fwds
+			item->from = g_strdup(username);
+			item->to = g_strdup(deliver_to);
+			*(GList **)fwds = g_list_prepend(*(GList **)fwds, item);
+		}
 		if (! g_list_next(d)) break;
 		d = g_list_next(d);
 	}


### PR DESCRIPTION
This push is about a feature which allows override sending address (override sender email_ when an alias is set to forward a message to an external email address. This helps the message to be be applied proper SPF and DKIM signatures.
In case delivery reports are sent to this email address, this feature is automatically disabled. Delivery reports are identified by analyzing various types of message parts and content type, according to rfc standard. 
It permits the following control capabilities (via dbmail.conf)
```
# 0 = no forward override, it preserves the original sender. (default)
# 1 = all forwards have the sender changed to the actual alias
# 2 = allows a finer degree of control by specifying which aliases can have their sender changed or not. When using authldap, 
#		the control is based on information written in dbmail_alias table, by switching on/off the override_fw_sender
#
```
forward_sender_override	   = 0
Also changes are performed into dbmail, refer to your specific upgrade schema
This feature is already in production (using another dbmail port https://github.com/cncioranu/dbmail/releases/tag/v3.5.1.rc6, beware this prerelease does contain other features such as mariadb galera db optimizations ), tested extensively on authsql (although changes were made also in authldap) 

