### PR TITLE
Errant Aii string removed from trace

### DIFF
--- a/src/dm_mailboxstate.c
+++ b/src/dm_mailboxstate.c
@@ -1102,7 +1102,7 @@ void db_getmailbox_seq(T M, Connection_T c)
 		M->seq = db_result_get_u64(r,1);
 		TRACE(TRACE_DEBUG,"id: [%" PRIu64 "] name: [%s] seq [%" PRIu64 "]", M->id, p_string_str(M->name), M->seq);
 	} else {
-		TRACE(TRACE_ERR,"Aii. No such mailbox mailbox_idnr: [%" PRIu64 "]", M->id);
+		TRACE(TRACE_ERR,"No such mailbox mailbox_idnr: [%" PRIu64 "]", M->id);
 	}
 }
 


### PR DESCRIPTION
Confusing text "Aii" in trace message adds no value and should be removed.