### PR TITLE
DBMail uses openssl so ref openssl-ciphers

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -211,7 +211,7 @@ tls_cert              =
 # A file containing a PEM format RSA or DSA key
 tls_key               =
 
-# A cipher list string in the format given in ciphers(1)
+# A cipher list string in the format given in openssl-ciphers(1)
 tls_ciphers           =
 
 


### PR DESCRIPTION
dbmail.conf should reference openssl-ciphers as there is no ciphers man page