### PR TITLE
Key formats are now ECDSA or RSA

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -208,7 +208,7 @@ tls_cafile            =
 # A file containing a PEM format certificate
 tls_cert              =
 
-# A file containing a PEM format RSA or DSA key
+# A file containing a PEM format ECDSA or RSA key
 tls_key               =
 
 # A cipher list string in the format given in openssl-ciphers(1)


### PR DESCRIPTION
20 Oct 2015 — DSS (DSA) keys were phased out from the major browsers.