### PR TITLE
Fix invalid free and invalid read

### DIFF
--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -1712,7 +1712,7 @@ static GList * _structure_part_multipart(GMimeObject *part, GList *structure, gb
 static GList * _structure_basic(GMimeObject *object)
 {
 	GList *list = NULL;
-	char *result;
+	const char *result;
 	const GMimeContentType *type;
 
 	type = g_mime_object_get_content_type(object);
@@ -1726,9 +1726,8 @@ static GList * _structure_basic(GMimeObject *object)
 	list = imap_append_header_as_string(list, object, "Content-Type");
 
 	/* body id */
-	if ((result = (char *)g_mime_object_get_content_id(object))) {
+	if ((result = g_mime_object_get_content_id(object))) {
 		list = g_list_append_printf(list,"\"%s\"", result);
-		g_free(result);
 	} else {
 		list = g_list_append_printf(list,"NIL");
 	}


### PR DESCRIPTION
Caused by UID FETCH [uid list] (UID BODYSTRUCTURE)

Touching dm_imapsession.c:195 (*id != self->message->id)

==71903== Thread 12 pool:
==71903== Invalid free() / delete / delete[] / realloc()
==71903==    at 0x48502BC: free (vg_replace_malloc.c:993)
==71903==    by 0x49C9180: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x4C20AB3: g_object_unref (in /usr/local/lib/libgobject-2.0.so.0.8000.5)
==71903==    by 0x49C5E8B: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x4C20AB3: g_object_unref (in /usr/local/lib/libgobject-2.0.so.0.8000.5)
==71903==    by 0x49C2F56: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x4C20AB3: g_object_unref (in /usr/local/lib/libgobject-2.0.so.0.8000.5)
==71903==    by 0x48A3245: dbmail_message_free (dm_message.c:727)
==71903==    by 0x224B3A: dbmail_imap_session_message_load (dm_imapsession.c:195)
==71903==    by 0x223D0C: _fetch_get_items (dm_imapsession.c:1128)
==71903==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==71903==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==71903==  Address 0xa0da270 is 0 bytes inside a block of size 10 free'd
==71903==    at 0x48502BC: free (vg_replace_malloc.c:993)
==71903==    by 0x48E462A: _structure_basic (dm_misc.c:1731)
==71903==    by 0x48E18B9: _structure_part_text (dm_misc.c:1803)
==71903==    by 0x48E3E96: _structure_part_handle_part (dm_misc.c:1646)
==71903==    by 0x48E149C: _structure_part_multipart (dm_misc.c:1682)
==71903==    by 0x48E11A6: imap_get_structure (dm_misc.c:1981)
==71903==    by 0x2240F2: _fetch_get_items (dm_imapsession.c:1168)
==71903==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==71903==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==71903==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==71903==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==71903==    by 0x48EECD9: dm_thread_dispatch (server.c:227)
==71903==  Block was alloc'd at
==71903==    at 0x484E2E4: malloc (vg_replace_malloc.c:450)
==71903==    by 0x4D3FA02: g_malloc (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==71903==    by 0x4D59AED: g_strndup (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==71903==    by 0x49CD7DD: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49DF3E8: g_mime_utils_decode_message_id (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49C9272: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49B4994: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49C0069: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49D01B7: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49CFCDB: ??? (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x49CE8C3: g_mime_parser_construct_message (in /usr/local/lib/libgmime-3.0.so.0.206.1)
==71903==    by 0x48A35A3: dbmail_message_init_with_string (dm_message.c:826)

==96940== Thread 7 pool:
==96940== Invalid read of size 8
==96940==    at 0x53B1276: Connection_close (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==    by 0x48EECC9: dm_thread_dispatch (server.c:227)
==96940==    by 0x4D672C7: ??? (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==  Address 0x7798798 is 72 bytes inside a block of size 80 free'd
==96940==    at 0x48502BC: free (vg_replace_malloc.c:993)
==96940==    by 0x53B0DA0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AF774: ConnectionPool_stop (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C4292: db_disconnect (dm_db.c:311)
==96940==    by 0x48EC84E: disconnect_all (server.c:710)
==96940==    by 0x48ED478: server_exit (server.c:525)
==96940==    by 0x5632F83: __cxa_finalize (in /lib/libc.so.7)
==96940==    by 0x56334DB: exit (in /lib/libc.so.7)
==96940==    by 0x48EC814: server_sig_cb (server.c:669)
==96940==    by 0x4E60C43: ??? (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x4E5CE3B: event_base_loop (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x48ED0B8: server_run (server.c:861)
==96940==  Block was alloc'd at
==96940==    at 0x4853155: calloc (vg_replace_malloc.c:1679)
==96940==    by 0x53ADD71: Mem_calloc (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0BF0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AFDBA: ConnectionPool_start (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C320C: db_connect (dm_db.c:281)
==96940==    by 0x48EC9EA: server_run (server.c:777)
==96940==    by 0x48EE8C4: server_mainloop (server.c:1007)
==96940==    by 0x22728F: main (imapd.c:55)
==96940==
==96940== Invalid read of size 4
==96940==    at 0x53B14A6: Connection_inTransaction (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B05C0: ConnectionPool_returnConnection (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==    by 0x48EECC9: dm_thread_dispatch (server.c:227)
==96940==  Address 0x7798778 is 40 bytes inside a block of size 80 free'd
==96940==    at 0x48502BC: free (vg_replace_malloc.c:993)
==96940==    by 0x53B0DA0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AF774: ConnectionPool_stop (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C4292: db_disconnect (dm_db.c:311)
==96940==    by 0x48EC84E: disconnect_all (server.c:710)
==96940==    by 0x48ED478: server_exit (server.c:525)
==96940==    by 0x5632F83: __cxa_finalize (in /lib/libc.so.7)
==96940==    by 0x56334DB: exit (in /lib/libc.so.7)
==96940==    by 0x48EC814: server_sig_cb (server.c:669)
==96940==    by 0x4E60C43: ??? (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x4E5CE3B: event_base_loop (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x48ED0B8: server_run (server.c:861)
==96940==  Block was alloc'd at
==96940==    at 0x4853155: calloc (vg_replace_malloc.c:1679)
==96940==    by 0x53ADD71: Mem_calloc (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0BF0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AFDBA: ConnectionPool_start (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C320C: db_connect (dm_db.c:281)
==96940==    by 0x48EC9EA: server_run (server.c:777)
==96940==    by 0x48EE8C4: server_mainloop (server.c:1007)
==96940==    by 0x22728F: main (imapd.c:55)
==96940==
==96940== Invalid read of size 8
==96940==    at 0x53B0DFB: Connection_clear (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B068D: ConnectionPool_returnConnection (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==    by 0x48EECC9: dm_thread_dispatch (server.c:227)
==96940==  Address 0x7798788 is 56 bytes inside a block of size 80 free'd
==96940==    at 0x48502BC: free (vg_replace_malloc.c:993)
==96940==    by 0x53B0DA0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AF774: ConnectionPool_stop (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C4292: db_disconnect (dm_db.c:311)
==96940==    by 0x48EC84E: disconnect_all (server.c:710)
==96940==    by 0x48ED478: server_exit (server.c:525)
==96940==    by 0x5632F83: __cxa_finalize (in /lib/libc.so.7)
==96940==    by 0x56334DB: exit (in /lib/libc.so.7)
==96940==    by 0x48EC814: server_sig_cb (server.c:669)
==96940==    by 0x4E60C43: ??? (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x4E5CE3B: event_base_loop (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x48ED0B8: server_run (server.c:861)
==96940==  Block was alloc'd at
==96940==    at 0x4853155: calloc (vg_replace_malloc.c:1679)
==96940==    by 0x53ADD71: Mem_calloc (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0BF0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AFDBA: ConnectionPool_start (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C320C: db_connect (dm_db.c:281)
==96940==    by 0x48EC9EA: server_run (server.c:777)
==96940==    by 0x48EE8C4: server_mainloop (server.c:1007)
==96940==    by 0x22728F: main (imapd.c:55)
==96940==
==96940== Invalid read of size 8
==96940==    at 0x53B0E0B: Connection_clear (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B068D: ConnectionPool_returnConnection (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==    by 0x48EECC9: dm_thread_dispatch (server.c:227)
==96940==  Address 0x7798770 is 32 bytes inside a block of size 80 free'd
==96940==    at 0x48502BC: free (vg_replace_malloc.c:993)
==96940==    by 0x53B0DA0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AF774: ConnectionPool_stop (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C4292: db_disconnect (dm_db.c:311)
==96940==    by 0x48EC84E: disconnect_all (server.c:710)
==96940==    by 0x48ED478: server_exit (server.c:525)
==96940==    by 0x5632F83: __cxa_finalize (in /lib/libc.so.7)
==96940==    by 0x56334DB: exit (in /lib/libc.so.7)
==96940==    by 0x48EC814: server_sig_cb (server.c:669)
==96940==    by 0x4E60C43: ??? (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x4E5CE3B: event_base_loop (in /usr/local/lib/libevent-2.1.so.7.0.1)
==96940==    by 0x48ED0B8: server_run (server.c:861)
==96940==  Block was alloc'd at
==96940==    at 0x4853155: calloc (vg_replace_malloc.c:1679)
==96940==    by 0x53ADD71: Mem_calloc (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0BF0: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53AFDBA: ConnectionPool_start (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C320C: db_connect (dm_db.c:281)
==96940==    by 0x48EC9EA: server_run (server.c:777)
==96940==    by 0x48EE8C4: server_mainloop (server.c:1007)
==96940==    by 0x22728F: main (imapd.c:55)
==96940==
==96940== Invalid read of size 4
==96940==    at 0x53ACD56: Vector_isEmpty (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0E13: Connection_clear (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B068D: ConnectionPool_returnConnection (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==96940==
==96940==
==96940== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==96940==  Access not within mapped region at address 0x0
==96940==    at 0x53ACD56: Vector_isEmpty (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B0E13: Connection_clear (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x53B068D: ConnectionPool_returnConnection (in /usr/local/lib/libzdb.so.16.0.0)
==96940==    by 0x48C34CE: db_con_close (dm_db.c:370)
==96940==    by 0x226A27: _fetch_headers (dm_imapsession.c:896)
==96940==    by 0x2258C8: _imap_show_body_section (dm_imapsession.c:1002)
==96940==    by 0x2255AE: _imap_show_body_sections (dm_imapsession.c:1093)
==96940==    by 0x2246A7: _fetch_get_items (dm_imapsession.c:1239)
==96940==    by 0x221010: _do_fetch (dm_imapsession.c:1293)
==96940==    by 0x4D6CCF4: g_tree_foreach (in /usr/local/lib/libglib-2.0.so.0.8000.5)
==96940==    by 0x220FB1: dbmail_imap_session_fetch_get_items (dm_imapsession.c:1310)
==96940==    by 0x2186DE: _ic_fetch_enter (imapcommands.c:2114)
==96940==  If you believe this happened as a result of a stack
==96940==  overflow in your program's main thread (unlikely but
==96940==  possible), you can try to increase the size of the
==96940==  main thread stack using the --main-stacksize= flag.
==96940==  The main thread stack size used in this run was 16777216.