### PR TITLE
Invalid read fixed in _header_insert

### DIFF
--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -1692,6 +1692,9 @@ static gboolean _header_insert(uint64_t physmessage_id, uint64_t headername_id, 
 		return t;
 	}
 
+	c = db_con_get();
+	db_con_clear(c);
+
 	TRY
 		db_begin_transaction(c);
 		s = db_stmt_prepare(c, "INSERT INTO %sheader (physmessage_id, headername_id, headervalue_id) VALUES (?,?,?)", DBPFX);


### PR DESCRIPTION
==3099== Thread 6 pool:
==3099== Invalid read of size 4
==3099==    at 0x5EDB7A9: vio_shutdown(Vio*) (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5EDC177: vio_ssl_delete(Vio*) (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E79130: end_server (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E781C4: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E82A5A: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E8087E: mysql_real_query (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x53B50D4: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x53B150C: Connection_commit (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x48C52AA: db_commit_transaction (dm_db.c:661)
==3099==    by 0x48A6772: _header_insert (dm_message.c:1702)
==3099==    by 0x48A714D: _header_cache (dm_message.c:1897)
==3099==    by 0x48A5334: dbmail_message_cache_headers (dm_message.c:1445)
==3099==  Address 0x77eab98 is 328 bytes inside a block of size 680 free'd
==3099==    at 0x48502BC: free (vg_replace_malloc.c:993)
==3099==    by 0x5E79130: end_server (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E781C4: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E78CA2: cli_advanced_command (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E71435: mysql_ping (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x53B4F2D: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x53B02DF: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x53B005E: ConnectionPool_getConnection (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x48C4363: db_con_get (dm_db.c:329)
==3099==    by 0x48CCF0E: db_findmailbox_owner (dm_db.c:2340)
==3099==    by 0x48CCDDE: db_findmailbox (dm_db.c:2422)
==3099==    by 0x48CF8F6: db_find_create_mailbox (dm_db.c:2960)
==3099==  Block was alloc'd at
==3099==    at 0x484E2E4: malloc (vg_replace_malloc.c:450)
==3099==    by 0x5EEA3B3: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5EDADB1: mysql_socket_vio_new(MYSQL_SOCKET, enum_vio_type, unsigned int) (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E7F71C: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E829D8: ??? (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x5E7EA2E: mysql_real_connect (in /usr/local/lib/mysql/libmysqlclient.so.21)
==3099==    by 0x53B4D91: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x53B0C8A: ??? (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x53AFDBA: ConnectionPool_start (in /usr/local/lib/libzdb.so.16.0.0)
==3099==    by 0x48C320C: db_connect (dm_db.c:281)
==3099==    by 0x48EC9EA: server_run (server.c:777)
==3099==    by 0x48EE8C4: server_mainloop (server.c:1007)