### PR TITLE
Enable logging to stderr for running under systemd or docker

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -158,7 +158,8 @@ file_logging_levels       = notice
 syslog_logging_levels     = warning
 
 #
-# Location and name of the logfile
+# Location and name of the logfile.  Set this to "stderr" if running
+# under docker or systemd, which expect to receive and handle log lines.
 #
 logfile               = /var/log/dbmail/dbmail.log
 

--- a/src/server.c
+++ b/src/server.c
@@ -335,14 +335,20 @@ int StartCliServer(ServerConfig_T * conf)
 static void reopen_logs_level(ServerConfig_T *conf, Trace_T level)
 {
 	int serr;
+	Field_T val;
 
 	if (mainReload) {
 		mainReload = 0;
 		TRACE(TRACE_INFO, "reopening log files");
 	}
 
-	if (fstdout) fclose(fstdout);
-	if (fstderr) fclose(fstderr);
+	config_get_value("logfile", "DBMAIL", val);
+	if (strncmp(val, "stderr", 6) == 0) {
+		TRACE(TRACE_INFO, "Keeping stdout and stderr open");
+	} else {
+		if (fstdout) fclose(fstdout);
+		if (fstderr) fclose(fstderr);
+	}
 	if (fnull) fclose(fnull);
 
 	SetTraceLevel(conf->service_name);
@@ -354,6 +360,10 @@ static void reopen_logs_level(ServerConfig_T *conf, Trace_T level)
 	//}
 
 	//if (! (fstderr = freopen(conf->error_log, "a", stderr))) {
+	if (strncmp(val, "stderr", 6) == 0) {
+		TRACE(TRACE_INFO, "Keeping stdout and stderr open");
+		return;
+	}
 	if (! (fstderr = freopen(conf->log, "a", stderr))) {
 		serr = errno;
 		TRACE(level, "freopen failed on [%s] [%s]", conf->error_log, strerror(serr));


### PR DESCRIPTION
Using docker, or running under systemd on Linux, logging is expected to go to stdout and/or stderr, to be handled by the host. These patches add a new log file destination, "stderr". When this is specified in the configuration file, the re-opening of stderr on a regular file will not happen, and the syslog log format will be used, as both docker and systemd, like syslog, will add the extra fields in the stderr (really log file) format.

Tested using docker on Redhat RHEL 9.