### PR TITLE
Turn off unsupported sieve_notify option by default

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -473,7 +473,7 @@ SIEVE_VACATION        = yes
 # 
 # Turn on/off the Sieve Notify extension
 #
-SIEVE_NOTIFY          = yes
+SIEVE_NOTIFY          = no
 
 # 
 # Turn on/off additional Sieve debugging.


### PR DESCRIPTION
Sieve notify is not supported by the sortsieve utility in src/modules/sortsieve.c, so turn it off by default in dbmail.conf.