### PR TITLE
Fix dbmail-users handling of options for listing users

### DIFF
--- a/man/dbmail-users.txt
+++ b/man/dbmail-users.txt
@@ -50,7 +50,7 @@ MODE
 -e, --empty-user-mailboxes user::
   Empty all mailboxes for a user
 
--l, --list-users::
+-L, --list-users::
   List information for all users
 
 -l, --list-user userspec::

--- a/src/user.c
+++ b/src/user.c
@@ -62,7 +62,7 @@ int do_showhelp(void)
 	"     -c, --change-user user   change details for a user\n"
 	"     -e, --empty-user-mailboxes user   empty all mailboxes for a user\n"
 	"     -l, --list-user user     list information for matching users\n"
-	"     -l, --list-users         list information for all users\n"
+	"     -L, --list-users         list information for all users\n"
 	"     -x, --forward address    create an external forwarding address\n"
 	"                              use with --add-forward and --delete-forward\n"
 	"\nSummary of options for all modes:\n"
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
 		{"delete-user", required_argument, NULL, 'd'},
 		{"empty-user-mailboxes", required_argument, NULL, 'e'},
 		{"list-user", required_argument, NULL, 'l'},
-		{"list-users", no_argument, NULL, 'l'},
+		{"list-users", no_argument, NULL, 'L'},
 		{"forward", required_argument, NULL, 'x'},
 
 		{"password", required_argument, NULL, 'w'},
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 	};
 	int option_index = 0;
 	while ((opt = getopt_long(argc, argv,
-				"a:d:c:e:l:x:" /* Major modes */
+				"a:d:c:e:l:Lx:" /* Major modes */
 				"W::w:P::p:u:g:m:t:s:S:T:" /* Minor options */
 				"i" "f:qnyvVh" /* Common options */,
 				long_options, &option_index)) != -1) {
@@ -196,13 +196,17 @@ int main(int argc, char *argv[])
 			break;
 
 		case 'l':
-			/* It seems that the optional argument may
-			 * be passed as a second instance of this flag. */
-			if (mode != 0 && mode != 'l')
+			if (mode)
 				mode_toomany = 1;
 			mode = opt;
 			if (optarg && strlen(optarg))
 				userspec = optarg;
+			break;
+
+		case 'L':
+			if (mode)
+				mode_toomany = 1;
+			mode = opt;
 			break;
 
 		case 'i':
@@ -528,14 +532,14 @@ int main(int argc, char *argv[])
 		result = do_empty(useridnr);
 		break;
 	case 'l':
-		if (userspec) {
-			qprintf("Listing information for user [%s]...\n", userspec);
-			TRACE(TRACE_INFO, "Listing information for user [%s]...", userspec);
-		} else {
-			qprintf("Listing information for all users\n");
-			TRACE(TRACE_INFO, "Listing information for all users");
-		}
+		qprintf("Listing information for user [%s]...\n", userspec);
+		TRACE(TRACE_INFO, "Listing information for user [%s]...", userspec);
 		result = do_show(userspec);
+		break;
+	case 'L':
+		qprintf("Listing information for all users\n");
+		TRACE(TRACE_INFO, "Listing information for all users");
+		result = do_show(NULL);
 		break;
 	case 'x':
 		if (g_list_length(fwds_add) == 0 && g_list_length(fwds_del) == 0) {


### PR DESCRIPTION
In dbmail-users, src/user.c, there's an attempt to use the same short option (-l) for two different long options (--list-user and --list-users), which does not work. This patch separates the options properly.

Tested on NetBSD and Redhat RHEL 9.