### PR TITLE
Allow TRACE() to be used after config resources have been freed

### DIFF
--- a/src/dm_debug.c
+++ b/src/dm_debug.c
@@ -135,7 +135,6 @@ void trace(Trace_T level, const char * module, const char * function, int line, 
 {
 	Trace_T syslog_level;
 	va_list ap, cp;
-	Field_T val;
 
 	char message[MESSAGESIZE];
 
@@ -167,9 +166,7 @@ void trace(Trace_T level, const char * module, const char * function, int line, 
  			configured=1;
  		}
  
-		config_get_value("logfile", "DBMAIL", val);
-
-		if (strncmp(val, "stderr", 6) == 0) {
+		if (!fstderr) {
 			fprintf(stderr, SYSLOGFORMAT, Trace_To_text(level), module, function, line, message);
 		} else {
 			memset(date,0,sizeof(date));


### PR DESCRIPTION
I was too quick with #451 -- TRACE() can be called at times when it's not possible to check config file values; notably during exit(), from handlers installed with atexit(). This leads to crashes.

However, the variable fstderr is initialized to NULL, and then set (from an freopen() call) if and only if the value of the paramer "logfile" is something other than "stderr", so it can be used to check for this instead.