### PR TITLE
Add a check whether the connection pool is stopped

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -205,6 +205,9 @@ query_time_warning    = 30
 # Throw an exception is the query takes longer than query_timeout seconds
 query_timeout         = 300 
 
+# Time in seconds to wait for a stopped connection pool before exiting (default: 30)
+connection_pool_timeout = 30
+
 ###################
 # Privileges
 #

--- a/dbmail.conf
+++ b/dbmail.conf
@@ -205,8 +205,12 @@ query_time_warning    = 30
 # Throw an exception is the query takes longer than query_timeout seconds
 query_timeout         = 300 
 
-# Time in seconds to wait for a stopped connection pool before exiting (default: 30)
-connection_pool_timeout = 30
+# Time in seconds to wait for a stopped connection pool before exiting (default: 90).
+# Keep this above the recoverable-reconnect worst case (~53s: db_connect succeeds on
+# the last retry after ~50s of backoff plus a 3s ping sleep) so a transient DB blip is
+# not turned into a process restart. An all-retries-fail stall (~78s) is unrecoverable,
+# so exiting past that point is the intended behavior. 90 clears both.
+connection_pool_timeout = 90
 
 ###################
 # Privileges

--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -307,6 +307,12 @@
 #define DEF_QUERYSIZE (32*1024)
 #define DEF_FRAGSIZE 256
 
+/* Default seconds to wait for a stopped connection pool before exiting.
+ * Long enough to ride out a transient database reconnect, short enough that a
+ * pool that stays stopped eventually makes the process exit with EX_TEMPFAIL so
+ * the service manager can restart it. */
+#define DEFAULT_CONNECTION_POOL_TIMEOUT 90
+
 /** default table prefix */
 #define DEFAULT_DBPFX "dbmail_"
 

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -120,6 +120,7 @@ typedef struct {
 	unsigned int query_time_notice;
 	unsigned int query_time_warning;
 	unsigned int query_timeout;
+	unsigned int connection_pool_timeout; /**< seconds to wait for stopped connection pool before exiting */
 } DBParam_T;
 
 enum DBMAIL_MESSAGE_CLASS {

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -409,7 +409,7 @@ void SetTraceLevel(const char *service_name)
 
 void GetDBParams(void)
 {
-	Field_T port_string, sock_string, serverid_string, query_time;
+	Field_T port_string, sock_string, serverid_string, query_time, timeout_string;
 	Field_T max_db_connections;
 
 	if (config_get_value("dburi", "DBMAIL", db_params.dburi) < 0) {
@@ -519,6 +519,15 @@ void GetDBParams(void)
 	else
 		db_params.query_timeout = 300000;
 
+	if (config_get_value("connection_pool_timeout", "DBMAIL",
+	                     timeout_string) < 0)
+		TRACE(TRACE_DEBUG,
+		      "error getting config! [connection_pool_timeout]");
+		if (strlen(timeout_string) != 0)
+			db_params.connection_pool_timeout =
+				(unsigned int) strtoul(timeout_string, NULL, 10);
+		else
+			db_params.connection_pool_timeout = 30;
 
 	if (strcmp(db_params.pfx, "\"\"") == 0) {
 		/* FIXME: It appears that when the empty string is quoted

--- a/src/dm_config.c
+++ b/src/dm_config.c
@@ -520,14 +520,35 @@ void GetDBParams(void)
 		db_params.query_timeout = 300000;
 
 	if (config_get_value("connection_pool_timeout", "DBMAIL",
-	                     timeout_string) < 0)
+	                     timeout_string) < 0) {
 		TRACE(TRACE_DEBUG,
 		      "error getting config! [connection_pool_timeout]");
-		if (strlen(timeout_string) != 0)
+	}
+	if (strlen(timeout_string) != 0) {
+		errno = 0;
+		unsigned long timeout_value = strtoul(timeout_string, NULL, 10);
+		/* strtoul() accepts a leading '-' (negates into a huge unsigned)
+		 * and flags overflow via ERANGE; it also returns unsigned long,
+		 * which is wider than connection_pool_timeout (unsigned int) on
+		 * LP64, so a value in (UINT_MAX, ULONG_MAX] would survive the cast
+		 * as a large finite timeout. Any of these would make the wait loop
+		 * effectively never time out, so fall back to the default. */
+		if (errno == EINVAL || errno == ERANGE ||
+		    timeout_value > UINT_MAX ||
+		    strchr(timeout_string, '-') != NULL) {
+			TRACE(TRACE_WARNING, "invalid connection_pool_timeout [%s], using default", timeout_string);
+			db_params.connection_pool_timeout = 0;
+		} else
 			db_params.connection_pool_timeout =
-				(unsigned int) strtoul(timeout_string, NULL, 10);
-		else
-			db_params.connection_pool_timeout = 30;
+				(unsigned int) timeout_value;
+	} else {
+		db_params.connection_pool_timeout = DEFAULT_CONNECTION_POOL_TIMEOUT;
+	}
+
+	/* a zero/garbage value would make db_con_get exit immediately whenever
+	 * the pool is stopped, including during a transient reconnect */
+	if (db_params.connection_pool_timeout == 0)
+		db_params.connection_pool_timeout = DEFAULT_CONNECTION_POOL_TIMEOUT;
 
 	if (strcmp(db_params.pfx, "\"\"") == 0) {
 		/* FIXME: It appears that when the empty string is quoted

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -194,6 +194,7 @@ GTree * global_cache = NULL;
 ConnectionPool_T pool = NULL;
 URL_T dburi = NULL;
 int db_connected = 0; // 0 = not called, 1 = new dburi but not pool, 2 = new dburi and pool, but not tested, 3 = tested and ok
+volatile int connection_pool_stopped = 0; // Indicates whether the connection pool has been stopped (1 = stopped, 0 = active).
 
 /* This is the first db_* call anybody should make. */
 int db_connect(void)
@@ -279,6 +280,7 @@ int db_connect(void)
 
 	ConnectionPool_setAbortHandler(pool, TabortHandler);
 	ConnectionPool_start(pool);
+	connection_pool_stopped = 0;
 	TRACE(TRACE_DATABASE, "database connection pool started with [%d] connections, max [%d]", 
 		ConnectionPool_getInitialConnections(pool), ConnectionPool_getMaxConnections(pool));
 
@@ -309,6 +311,7 @@ int db_connect(void)
 int db_disconnect(void)
 {
 	TRACE(TRACE_DEBUG,"Disconnecting debug");
+	connection_pool_stopped = 1;
 	if(db_connected >= 3) ConnectionPool_stop(pool);
 	if(db_connected >= 2) ConnectionPool_free(&pool);
 	if(db_connected >= 1) URL_free(&dburi);
@@ -328,8 +331,18 @@ const char *db_get_db_name(void)
  */
 Connection_T db_con_get(void)
 {
-	int i=0, k=0; Connection_T c = NULL;
+	unsigned int i=0; int k=0; Connection_T c = NULL;
 	while (! c) {
+		if (connection_pool_stopped) {
+			if (i % 5 == 0 || i >= db_params.connection_pool_timeout)
+				TRACE(i >= db_params.connection_pool_timeout ? TRACE_EMERG : TRACE_ALERT,
+				      "Connection pool stopped for [%u] sec%s", i,
+				      i >= db_params.connection_pool_timeout ? ", timed out, exiting" : "");
+			sleep(1);
+			i++;
+			continue;
+		}
+
 		TRY
 			c = ConnectionPool_getConnectionOrException(pool);
 		CATCH(SQLException)

--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -334,10 +334,12 @@ Connection_T db_con_get(void)
 	unsigned int i=0; int k=0; Connection_T c = NULL;
 	while (! c) {
 		if (connection_pool_stopped) {
-			if (i % 5 == 0 || i >= db_params.connection_pool_timeout)
-				TRACE(i >= db_params.connection_pool_timeout ? TRACE_EMERG : TRACE_ALERT,
-				      "Connection pool stopped for [%u] sec%s", i,
-				      i >= db_params.connection_pool_timeout ? ", timed out, exiting" : "");
+			if (i >= db_params.connection_pool_timeout) {
+				TRACE(TRACE_ALERT, "Connection pool stopped for [%u] sec, timed out, exiting", i);
+				exit(EX_TEMPFAIL);
+			}
+			if (i % 5 == 0)
+				TRACE(TRACE_ALERT, "Connection pool stopped for [%u] sec", i);
 			sleep(1);
 			i++;
 			continue;
@@ -353,7 +355,7 @@ Connection_T db_con_get(void)
 		END_TRY;
 		if (c) break;
 		if((int)(i % 5)==0) {
-			TRACE(TRACE_ALERT, "Thread is having trouble obtaining a database connection. Try [%d]", i);
+			TRACE(TRACE_ALERT, "Thread is having trouble obtaining a database connection. Try [%u]", i);
 			k = ConnectionPool_reapConnections(pool);
 			TRACE(TRACE_INFO, "Database reaper closed [%d] stale connections", k);
 		}

--- a/src/server.c
+++ b/src/server.c
@@ -721,15 +721,15 @@ static int server_set_sighandler(void)
 void disconnect_all(void)
 {
 	TRACE(TRACE_INFO, "disconnecting all");
-	db_disconnect();
-	auth_disconnect();
-	g_mime_shutdown();
-	config_free();
 
 	if (tpool) { 
 		g_thread_pool_free(tpool, TRUE, TRUE);
 		tpool = NULL;
 	}
+	db_disconnect();
+	auth_disconnect();
+	g_mime_shutdown();
+	config_free();
 	if (sig_int) {
 		event_free(sig_int);
 		sig_int = NULL;

--- a/test/check_dbmail_connection_pool.c
+++ b/test/check_dbmail_connection_pool.c
@@ -1,0 +1,97 @@
+#include <check.h>
+#include <pthread.h>
+#include <sysexits.h>
+#include "check_dbmail.h"
+
+extern char configFile[PATH_MAX];
+extern DBParam_T db_params;
+
+/*
+ * Number of threads competing for connections simultaneously.
+ * Matches the max_db_connections=20 setting from the production crash scenario.
+ */
+#define TEST_THREAD_COUNT 20
+
+static pthread_barrier_t all_threads_ready;
+
+/*
+ *
+ * the test fixtures
+ *
+ */
+void setup(void)
+{
+	config_get_file();
+	config_read(configFile);
+	configure_debug(NULL, 511, 0);
+	GetDBParams();
+	db_connect();
+	db_params.connection_pool_timeout = 2;
+}
+
+void teardown(void)
+{
+}
+
+/* Thread entry: synchronizes at the barrier, then requests a connection. */
+static void *get_connection_thread(void *arg)
+{
+	(void)arg;
+	pthread_barrier_wait(&all_threads_ready);
+	db_con_get();
+	return NULL;
+}
+
+/*
+ * Verify db_con_get() behaviour when the pool is stopped while multiple
+ * threads are competing for connections:
+ *
+ * Requires CK_FORK=yes (the default) because the test exits the process.
+ */
+START_TEST(test_db_pool_exits_after_timeout)
+{
+	pthread_t threads[TEST_THREAD_COUNT];
+	int i;
+
+	pthread_barrier_init(&all_threads_ready, NULL, TEST_THREAD_COUNT + 1);
+
+	for (i = 0; i < TEST_THREAD_COUNT; i++)
+		pthread_create(&threads[i], NULL, get_connection_thread, NULL);
+
+	/* Stop the pool, then release all threads at once.
+	 * Reproduces a race where threads try to get a connection
+	 * from a stopped pool.
+	 */
+	db_disconnect();
+	pthread_barrier_wait(&all_threads_ready);
+
+	for (i = 0; i < TEST_THREAD_COUNT; i++)
+		pthread_join(threads[i], NULL);
+}
+END_TEST
+
+Suite *dbmail_connection_pool_suite(void)
+{
+	Suite *s = suite_create("Dbmail Connection Pool");
+	TCase *tc = tcase_create("ConnectionPool");
+
+	suite_add_tcase(s, tc);
+
+	tcase_add_checked_fixture(tc, setup, teardown);
+	tcase_set_timeout(tc, 10);
+	tcase_add_exit_test(tc, test_db_pool_exits_after_timeout, EX_TEMPFAIL);
+
+	return s;
+}
+
+int main(void)
+{
+	int nf;
+	Suite *s = dbmail_connection_pool_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_ENV);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/check_dbmail_connection_pool.c
+++ b/test/check_dbmail_connection_pool.c
@@ -7,7 +7,7 @@ extern char configFile[PATH_MAX];
 extern DBParam_T db_params;
 
 /*
- * Number of threads competing for connections simultaneously.
+ * Number of worker threads that hit the stopped pool simultaneously.
  * Matches the max_db_connections=20 setting from the production crash scenario.
  */
 #define TEST_THREAD_COUNT 20
@@ -23,7 +23,7 @@ void setup(void)
 {
 	config_get_file();
 	config_read(configFile);
-	configure_debug(NULL, 511, 0);
+	configure_debug(NULL, 511, 511);
 	GetDBParams();
 	db_connect();
 	db_params.connection_pool_timeout = 2;
@@ -43,8 +43,11 @@ static void *get_connection_thread(void *arg)
 }
 
 /*
- * Verify db_con_get() behaviour when the pool is stopped while multiple
- * threads are competing for connections:
+ * Verify db_con_get() exits with EX_TEMPFAIL once a stopped connection pool
+ * stays stopped past connection_pool_timeout. The pool is stopped before the
+ * threads are released, so each one deterministically takes the stopped branch
+ * and waits out the timeout -- this validates the timeout-exit path, not
+ * connection contention.
  *
  * Requires CK_FORK=yes (the default) because the test exits the process.
  */
@@ -53,14 +56,17 @@ START_TEST(test_db_pool_exits_after_timeout)
 	pthread_t threads[TEST_THREAD_COUNT];
 	int i;
 
-	pthread_barrier_init(&all_threads_ready, NULL, TEST_THREAD_COUNT + 1);
+	ck_assert_int_eq(pthread_barrier_init(&all_threads_ready, NULL,
+	                                      TEST_THREAD_COUNT + 1), 0);
 
 	for (i = 0; i < TEST_THREAD_COUNT; i++)
-		pthread_create(&threads[i], NULL, get_connection_thread, NULL);
+		ck_assert_int_eq(pthread_create(&threads[i], NULL,
+		                                get_connection_thread, NULL), 0);
 
-	/* Stop the pool, then release all threads at once.
-	 * Reproduces a race where threads try to get a connection
-	 * from a stopped pool.
+	/* Stop the pool before releasing the threads, so every thread finds
+	 * connection_pool_stopped already set when it calls db_con_get().
+	 * This exercises the timeout path: all threads wait out
+	 * connection_pool_timeout and the process exits with EX_TEMPFAIL.
 	 */
 	db_disconnect();
 	pthread_barrier_wait(&all_threads_ready);

--- a/test/check_dbmail_connection_pool_crash.c
+++ b/test/check_dbmail_connection_pool_crash.c
@@ -1,0 +1,95 @@
+#include <check.h>
+#include <pthread.h>
+#include <signal.h>
+#include "check_dbmail.h"
+
+extern char configFile[PATH_MAX];
+
+/*
+ * Number of threads competing for connections simultaneously.
+ * Matches the max_db_connections=20 setting from the production crash scenario.
+ */
+#define TEST_THREAD_COUNT 20
+
+static pthread_barrier_t all_threads_ready;
+
+/*
+ *
+ * the test fixtures
+ *
+ */
+void setup(void)
+{
+	config_get_file();
+	config_read(configFile);
+	configure_debug(NULL, 255, 0);
+	GetDBParams();
+	db_connect();
+}
+
+void teardown(void)
+{
+}
+
+/* Thread entry: synchronizes at the barrier, then requests a connection. */
+static void *get_connection_thread(void *arg)
+{
+	(void)arg;
+	pthread_barrier_wait(&all_threads_ready);
+	db_con_get();
+	return NULL;
+}
+
+/*
+ * Verify that stopping the pool while threads are waiting crashes unpatched
+ * DBMail (SIGSEGV in ConnectionPool_getConnection(NULL)).
+ *
+ * Requires CK_FORK=yes (the default).
+ */
+START_TEST(test_db_pool_crashes_on_stopped_pool)
+{
+	pthread_t threads[TEST_THREAD_COUNT];
+	int i;
+
+	pthread_barrier_init(&all_threads_ready, NULL, TEST_THREAD_COUNT + 1);
+
+	for (i = 0; i < TEST_THREAD_COUNT; i++)
+		pthread_create(&threads[i], NULL, get_connection_thread, NULL);
+
+	/* Stop the pool, then release all threads at once.
+	 * Reproduces a race where threads try to get a connection
+	 * from a stopped pool.
+	 */
+	db_disconnect();
+	pthread_barrier_wait(&all_threads_ready);
+
+	for (i = 0; i < TEST_THREAD_COUNT; i++)
+		pthread_join(threads[i], NULL);
+}
+END_TEST
+
+Suite *dbmail_connection_pool_crash_suite(void)
+{
+	Suite *s = suite_create("Dbmail Connection Pool Crash");
+	TCase *tc = tcase_create("ConnectionPoolCrash");
+
+	suite_add_tcase(s, tc);
+
+	tcase_add_checked_fixture(tc, setup, teardown);
+	tcase_set_timeout(tc, 10);
+	tcase_add_test_raise_signal(tc, test_db_pool_crashes_on_stopped_pool, SIGSEGV);
+
+	return s;
+}
+
+int main(void)
+{
+	int nf;
+	Suite *s = dbmail_connection_pool_crash_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_ENV);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
This change helps avoid returning an uninitialized connection and reduces the risk of DBMail crashing when the pool is no longer active.