### PR TITLE
Fix log level comparisons that choose level of detail

### DIFF
--- a/src/dm_debug.c
+++ b/src/dm_debug.c
@@ -168,7 +168,7 @@ void trace(Trace_T level, const char * module, const char * function, int line, 
  		}
 
 		if (!fstderr) {
-			if (TRACE_STDERR > TRACE_NOTICE)
+			if (TRACE_STDERR >= TRACE_INFO)
 				fprintf(stderr, SYSLOGDETAIL, Trace_To_text(level), module, function, line, message);
 			else
 				fprintf(stderr, SYSLOGFORMAT, Trace_To_text(level), message);
@@ -225,7 +225,7 @@ void trace(Trace_T level, const char * module, const char * function, int line, 
 			l = MESSAGESIZE;
 			message[l - 1] = 0;
 		}
-		if (TRACE_SYSLOG > LOG_NOTICE)
+		if (TRACE_SYSLOG >= TRACE_INFO)
 			syslog(syslog_level, SYSLOGDETAIL, Trace_To_text(level), module, function, line, message);
 		else
 			syslog(syslog_level, SYSLOGFORMAT, Trace_To_text(level), message);


### PR DESCRIPTION
Because we're comparing bit maps, here, we need to use the bit on the right side of the desired split.