### PR TITLE
Fix connection logging when resolve_ip is set

### DIFF
--- a/src/clientbase.c
+++ b/src/clientbase.c
@@ -152,34 +152,27 @@ ClientBase_T * client_init(client_sock *c)
 		client->tx		= STDOUT_FILENO;
 	} else {
 		/* server-side */
-		if ((serr = getnameinfo(&c->saddr, c->saddr_len, client->dst_ip, 
-						NI_MAXHOST, client->dst_port, 
-						NI_MAXSERV, NI_NUMERICHOST | NI_NUMERICSERV))) {
+		if ((serr = getnameinfo(&c->saddr, c->saddr_len, client->dst_ip, NI_MAXHOST,
+					client->dst_port, NI_MAXSERV, NI_NUMERICHOST | NI_NUMERICSERV))) {
 			TRACE(TRACE_INFO, "getnameinfo::error [%s]", gai_strerror(serr));
 		}
 
 		/* client-side */
+		if ((serr = getnameinfo(&c->caddr, c->caddr_len, client->src_ip, NI_MAXHOST-1,
+					client->src_port, NI_MAXSERV-1, NI_NUMERICHOST | NI_NUMERICSERV))) {
+			TRACE(TRACE_INFO, "getnameinfo:error [%s]", gai_strerror(serr));
+		}
 		if (server_conf->resolveIP) {
-			if ((serr = getnameinfo(&c->caddr, c->caddr_len, client->clientname,
-						       	NI_MAXHOST-1, NULL, 0, NI_NAMEREQD))) {
+			if ((serr = getnameinfo(&c->caddr, c->caddr_len, client->clientname, NI_MAXHOST-1,
+						NULL, 0, NI_NAMEREQD))) {
 				TRACE(TRACE_INFO, "getnameinfo:error [%s]", gai_strerror(serr));
-			} 
-
+			}
 			TRACE(TRACE_NOTICE, "incoming connection on [%s:%s] from [%s:%s (%s)]",
-					client->dst_ip, client->dst_port,
-					client->src_ip, client->src_port,
-					client->clientname[0] ? client->clientname : "Lookup failed");
+			      client->dst_ip, client->dst_port, client->src_ip, client->src_port,
+			      client->clientname[0] ? client->clientname : "Lookup failed");
 		} else {
-
-			if ((serr = getnameinfo(&c->caddr, c->caddr_len, client->src_ip,
-						       	NI_MAXHOST-1, client->src_port,
-						       	NI_MAXSERV-1, NI_NUMERICHOST | NI_NUMERICSERV))) {
-				TRACE(TRACE_INFO, "getnameinfo:error [%s]", gai_strerror(serr));
-			} 
-
-			TRACE(TRACE_NOTICE, "incoming connection on [%s:%s] from [%s:%s]", 
-					client->dst_ip, client->dst_port,
-					client->src_ip, client->src_port);
+			TRACE(TRACE_NOTICE, "incoming connection on [%s:%s] from [%s:%s]",
+			      client->dst_ip, client->dst_port, client->src_ip, client->src_port);
 		}
 
 		/* make streams */


### PR DESCRIPTION
If you set "resolve_ip = yes" in the config file, you should get the host name of the client logged in addition to the IP address and port number. The current structure of the code involved is wrong: the IP address and port are not logged in this case.

This patch restructures things so that all the required information is generated and printed, for each setting of the parameter.