### PR TITLE
Make imapd log lines consistently include the session identifier

### DIFF
--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -178,7 +178,7 @@ static uint64_t dbmail_imap_session_message_load(ImapSession *self)
 		}else{
 			/* previous behavior, a query will be performed in db */
 			if ((db_get_physmessage_id(self->msg_idnr, id)) != DM_SUCCESS) {
-				TRACE(TRACE_ERR,"can't find physmessage_id for message_idnr [%" PRIu64 "]", self->msg_idnr);
+				TRACE(TRACE_ERR,"[%p] can't find physmessage_id for message_idnr [%" PRIu64 "]", self, self->msg_idnr);
 				mempool_push(self->pool, id, sizeof(uint64_t));
 				g_free(id);
 				return 0;
@@ -207,7 +207,7 @@ static uint64_t dbmail_imap_session_message_load(ImapSession *self)
 	}
 
 	if (! self->message) {
-		TRACE(TRACE_ERR,"message retrieval failed");
+		TRACE(TRACE_ERR,"[%p] message retrieval failed", self);
 		return 0;
 	}
 

--- a/src/export.c
+++ b/src/export.c
@@ -103,7 +103,7 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 	s->ci = client_init(c);
 	if (! (imap4_tokenizer_main(s, search))) {
 		qprintf("error parsing search string\n");
-		TRACE(TRACE_ERR, "Error parsing search string");
+		TRACE(TRACE_ERR, "[%p] Error parsing search string", s);
 		dbmail_mailbox_free(mb);
 		dbmail_imap_session_delete(&s);
 		return 1;
@@ -111,7 +111,7 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 
 	if (dbmail_mailbox_build_imap_search(mb, s->args, &(s->args_idx), SEARCH_UNORDERED) < 0) {
 		qprintf("Invalid search string\n");
-		TRACE(TRACE_INFO, "Invalid search string");
+		TRACE(TRACE_INFO, "[%p] Invalid search string", s);
 		dbmail_mailbox_free(mb);
 		dbmail_imap_session_delete(&s);
 		return 1;
@@ -123,14 +123,14 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 	} else if (! (ostream = fopen(dumpfile, "a"))) {
 		int err = errno;
 		qprintf("Opening [%s] failed [%s]\n", dumpfile, strerror(err));
-		TRACE(TRACE_ERR, "Opening [%s] failed [%s]", dumpfile, strerror(err));
+		TRACE(TRACE_ERR, "[%p] Opening [%s] failed [%s]", s, dumpfile, strerror(err));
 		result = -1;
 		goto cleanup;
 	}
 
 	if (dbmail_mailbox_dump(mb, ostream) < 0) {
 		qprintf("Export failed\n");
-		TRACE(TRACE_ERR, "Export failed");
+		TRACE(TRACE_ERR, "[%p] Export failed", s);
 		result = -1;
 		goto cleanup;
 	}
@@ -151,7 +151,7 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 			if (delete_after_dump & 1) {
 				if (db_set_msgflag(*(uint64_t *)ids->data, deleted_flag, NULL, IMAPFA_ADD, 0, NULL) < 0) {
 					qprintf("Error setting flags for message [%" PRIu64 "]\n", *(uint64_t *)ids->data);
-					TRACE(TRACE_ERR, "Error setting flags for message [%" PRIu64 "]", *(uint64_t *)ids->data);
+					TRACE(TRACE_ERR, "[%] Error setting flags for message [%" PRIu64 "]", s, *(uint64_t *)ids->data);
 					result = -1;
 				} else {
 					affected = 1;
@@ -163,7 +163,7 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 			if (delete_after_dump & 2) {
 				if (! db_set_message_status(*(uint64_t *)ids->data, MESSAGE_STATUS_DELETE)) {
 					qprintf("Error setting status for message [%" PRIu64 "]\n", *(uint64_t *)ids->data);
-					TRACE(TRACE_ERR, "Error setting status for message [%" PRIu64 "]\n", *(uint64_t *)ids->data);
+					TRACE(TRACE_ERR, "[%p] Error setting status for message [%" PRIu64 "]\n", s, *(uint64_t *)ids->data);
 					result = -1;
 				} else {
 					affected = 1;

--- a/src/export.c
+++ b/src/export.c
@@ -151,7 +151,7 @@ static int mailbox_dump(uint64_t mailbox_idnr, const char *dumpfile,
 			if (delete_after_dump & 1) {
 				if (db_set_msgflag(*(uint64_t *)ids->data, deleted_flag, NULL, IMAPFA_ADD, 0, NULL) < 0) {
 					qprintf("Error setting flags for message [%" PRIu64 "]\n", *(uint64_t *)ids->data);
-					TRACE(TRACE_ERR, "[%] Error setting flags for message [%" PRIu64 "]", s, *(uint64_t *)ids->data);
+					TRACE(TRACE_ERR, "[%p] Error setting flags for message [%" PRIu64 "]", s, *(uint64_t *)ids->data);
 					result = -1;
 				} else {
 					affected = 1;

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -616,7 +616,7 @@ int imap_handle_connection(client_sock *c)
 
 	session = dbmail_imap_session_new(c->pool);
 
-	TRACE(TRACE_NOTICE, "[%p] session established for [%s:%s (%s)]", session, ci->src_ip, ci->src_port, ci->clientname[0] ? ci->clientname : "Lookup failed");
+	TRACE(TRACE_NOTICE, "[%p] session established for [%s:%s]", session, ci->src_ip, ci->src_port);
 
 	assert(evbase);
 	ci->rev = event_new(evbase, ci->rx, EV_READ|EV_PERSIST, socket_read_cb, (void *)session);

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -616,6 +616,8 @@ int imap_handle_connection(client_sock *c)
 
 	session = dbmail_imap_session_new(c->pool);
 
+	TRACE(TRACE_NOTICE, "[%p] session established for [%s:%s (%s)]", session, ci->src_ip, ci->src_port, ci->clientname[0] ? ci->clientname : "Lookup failed");
+
 	assert(evbase);
 	ci->rev = event_new(evbase, ci->rx, EV_READ|EV_PERSIST, socket_read_cb, (void *)session);
 	ci->wev = event_new(evbase, ci->tx, EV_WRITE, socket_write_cb, (void *)session);
@@ -785,7 +787,7 @@ int imap4(ImapSession *session)
 
 	session->command_state=TRUE; // set command-is-done-state while doing some checks
 	if (! (session->tag[0] && session->command[0])) {
-		TRACE(TRACE_ERR,"no tag or command");
+		TRACE(TRACE_ERR,"[%p] no tag or command", session);
 		return 1;
 	}
 	if (! session->args) {
@@ -807,6 +809,6 @@ int imap4(ImapSession *session)
 
 	imap_unescape_args(session);
 
-	TRACE(TRACE_INFO, "dispatch [%s]...\n", IMAP_COMMANDS[session->command_type]);
+	TRACE(TRACE_INFO, "[%p] dispatch [%s]...\n", session, IMAP_COMMANDS[session->command_type]);
 	return (*imap_handler_functions[session->command_type]) (session);
 }

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -2235,7 +2235,7 @@ static gboolean _do_store(uint64_t *id, gpointer UNUSED value, dm_thread_data *D
 		if (cmd_store_silent==1 && changed){
 			showflags = showflags || changed;
 		}
-		TRACE(TRACE_INFO,"requested FLAGS.SILENT but a change was detected into mailbox and command_store_flags_silent_ignore_silent=%d so ignore FLAGS.SILENT and return message information with flags",cmd_store_silent);
+		TRACE(TRACE_INFO,"[%p] requested FLAGS.SILENT but a change was detected into mailbox and command_store_flags_silent_ignore_silent=%d so ignore FLAGS.SILENT and return message information with flags", self, cmd_store_silent);
 
 		_fetch_update(self, msginfo, showmodseq, showflags);
 	}
@@ -2457,7 +2457,7 @@ static gboolean _do_copy(uint64_t *id, gpointer UNUSED value, ImapSession *self)
 	int result;
 	uint64_t *new_ids_element = NULL;
 	if (!g_tree_lookup(self->mailbox->mbstate->msginfo, id)){
-		TRACE(TRACE_WARNING,"Copy message [%ld] failed security issue, trying to copy message that are not in this mailbox",*id);
+		TRACE(TRACE_WARNING,"[%p] Copy message [%ld] failed security issue, trying to copy message that are not in this mailbox", self, *id);
 		//dbmail_imap_session_buff_printf(self, "%s NO security issue, trying to copy message that are not in this mailbox\r\n",self->tag);
 		return FALSE;
 	}
@@ -2465,15 +2465,15 @@ static gboolean _do_copy(uint64_t *id, gpointer UNUSED value, ImapSession *self)
 	db_message_set_seq(*id, cmd->seq);
 	if (result == -1) {
 		/* uid not found, according to RFC 3501 section 6.4.8, should continue  */
-		TRACE(TRACE_WARNING,"Copy message [%ld] failed due to missing in database. continue.",*id);
+		TRACE(TRACE_WARNING,"[%p] Copy message [%ld] failed due to missing in database. continue.", self, *id);
 		/* continue operation, do not close or send various info on connection */
 		//dbmail_imap_session_buff_printf(self, "* BYE internal dbase error\r\n");
 		//return TRUE;
 		return FALSE;
 	}
 	if (result == -2) {
-		TRACE(TRACE_WARNING,"Copy message [%ld] failed due to `%s NO quotum would exceed`",*id,self->tag);
-		dbmail_imap_session_buff_printf(self, "%s NO quotum would exceed\r\n", self->tag);
+		TRACE(TRACE_WARNING,"[%p] Copy message [%ld] failed due to `%s NO quota would be exceeded`", self, *id, self->tag);
+		dbmail_imap_session_buff_printf(self, "%s NO quota would be exceeded\r\n", self->tag);
 		return TRUE;
 	}
 	// insert the new uid to the new_ids collection


### PR DESCRIPTION
I've just had to debug connection establishment problems for an IMAP client. Having the session ID included in all relevant log lines is very important when you're studying a single connection among many. This patch fixes the relatively few occurrences of TRACE calls at non-DEBUG levels in IMAP code that were missing this information.

Additionally, a TRACE call is added, in imap4.c, to log, with session ID, the establishment of a new session. This is done to document the session ID of the new connection as early as possible, making it easy to extract from the log all lines relevant to a particular session, by searching for the ID.

While here, fix the wording of the "quota exceeded" error situation. :)