### PR TITLE
Clean up and fix capability tweaking code

### DIFF
--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -124,6 +124,11 @@ ImapSession * dbmail_imap_session_new(Mempool_T pool)
 	Capa_remove(self->preauth_capa, "ENABLE");
 	Capa_remove(self->preauth_capa, "QRESYNC");
 
+	Capa_remove(self->capa, "STARTTLS");
+	Capa_remove(self->capa, "AUTH=LOGIN");
+	Capa_remove(self->capa, "AUTH=CRAM-MD5");
+	Capa_remove(self->capa, "LOGINDISABLED");
+
 	self->physids = g_tree_new((GCompareFunc)ucmp);
 	self->mbxinfo = g_tree_new_full((GCompareDataFunc)ucmpdata,NULL,(GDestroyNotify)uint64_free,(GDestroyNotify)mailboxstate_destroy);
 
@@ -1367,8 +1372,8 @@ int dbmail_imap_session_handle_auth(ImapSession * self, const char * username, c
 				char *enctype = NULL;
 				if (userid) enctype = auth_getencryption(userid);
 				if ((! enctype) || (! MATCH(enctype,""))) {
-					Capa_remove(self->capa,"AUTH=CRAM-MD5");
-					dbmail_imap_session_buff_printf(self, "* CAPABILITY %s\r\n", Capa_as_string(self->capa));
+					Capa_remove(self->preauth_capa,"AUTH=CRAM-MD5");
+					dbmail_imap_session_buff_printf(self, "* CAPABILITY %s\r\n", Capa_as_string(self->preauth_capa));
 				}
 				if (enctype) g_free(enctype);
 			}
@@ -1760,8 +1765,6 @@ int dbmail_imap_session_set_state(ImapSession *self, ClientState_T state)
 			assert(self->ci);
 			TRACE(TRACE_DEBUG,"[%p] set timeout to [%d]", self, server_conf->timeout);
 			self->ci->timeout.tv_sec = server_conf->timeout; 
-			Capa_remove(self->capa, "AUTH=login");
-			Capa_remove(self->capa, "AUTH=CRAM-MD5");
 
 			break;
 

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -635,7 +635,6 @@ int imap_handle_connection(client_sock *c)
 		login_disabled = FALSE;
 
 	if ((! server_conf->ssl) || (ci->sock->ssl_state == TRUE)) {
-		Capa_remove(session->capa, "STARTTLS");
 		Capa_remove(session->preauth_capa, "STARTTLS");
 		login_disabled = FALSE;
 	}
@@ -649,10 +648,8 @@ int imap_handle_connection(client_sock *c)
 		Capa_remove(session->preauth_capa, "LOGINDISABLED");
 	}
 
-	if (MATCH(db_params.authdriver, "LDAP")) {
-		Capa_remove(session->capa, "AUTH=CRAM-MD5");
+	if (MATCH(db_params.authdriver, "LDAP"))
 		Capa_remove(session->preauth_capa, "AUTH=CRAM-MD5");
-	}
 
 	fd_count = get_opened_fd_count();
 	if (fd_count < 0 || getrlimit(RLIMIT_NPROC, &fd_limit) < 0) {

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -154,7 +154,8 @@ static int check_state_and_args(ImapSession * self, int minargs, int maxargs, Cl
 void _ic_capability_enter(dm_thread_data *D)
 {
 	SESSION_GET;
-	dbmail_imap_session_buff_printf(self, "* %s %s\r\n", self->command, Capa_as_string(self->capa));
+	dbmail_imap_session_buff_printf(self, "* %s %s\r\n", self->command,
+		Capa_as_string(self->state == CLIENTSTATE_NON_AUTHENTICATED ? self->preauth_capa : self->capa));
 	SESSION_OK;
 	SESSION_RETURN;
 }
@@ -180,10 +181,15 @@ int _ic_starttls(ImapSession *self)
 	}
 	ci_write(self->ci, "%s OK Begin TLS now\r\n", self->tag);
 	i = ci_starttls(self->ci);
-	
-	Capa_remove(self->capa, "STARTTLS");
-	Capa_remove(self->capa, "LOGINDISABLED");
-	
+
+	Capa_remove(self->preauth_capa, "STARTTLS");
+	Capa_remove(self->preauth_capa, "LOGINDISABLED");
+	if (! Capa_match(self->preauth_capa, "AUTH=LOGIN"))
+		Capa_add(self->preauth_capa, "AUTH=LOGIN");
+	if (! MATCH(db_params.authdriver, "LDAP"))
+		if (! Capa_match(self->preauth_capa, "AUTH=CRAM-MD5"))
+			Capa_add(self->preauth_capa, "AUTH=CRAM-MD5");
+
 	if (i < 0) i = 0;
 
 	if (i == 0) return 3; /* done */


### PR DESCRIPTION
When a new IMAP session is established, a new set of capabilities is initiated by dbmail_imap_session_new(), in dm_imapsession.c, called from imap_handle_connection() in imap4.c. The capabilities are adapted to the actual situation on hand, by code in both of those functions. The logic is complicated, and the interaction between the two functions is faulty.

This patch leaves the establishment of the base set of capabilities in dbmail_imap_session_new(), and moves all the adjustments into imap_handle_connection(). As a result, it becomes easy to do the right tweaks with a minimum of code.

This fixes issue #466.