### PR TITLE
Allow building on NetBSD and add sample startup scripts.

### DIFF
--- a/contrib/startup-scripts/netbsd/dbmail_httpd
+++ b/contrib/startup-scripts/netbsd/dbmail_httpd
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# PROVIDE: dbmail_httpd
+# REQUIRE: DAEMON
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="dbmail_httpd"
+rcvar=$name
+
+command="/usr/local/sbin/dbmail-httpd"
+command_args=""
+pidfile=/var/run/dbmail/dbmail-httpd.pid
+
+load_rc_config $name
+run_rc_command "$1"

--- a/contrib/startup-scripts/netbsd/dbmail_imapd
+++ b/contrib/startup-scripts/netbsd/dbmail_imapd
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# PROVIDE: dbmail_imapd
+# REQUIRE: DAEMON
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="dbmail_imapd"
+rcvar=$name
+
+command="/usr/local/sbin/dbmail-imapd"
+command_args=""
+pidfile=/var/run/dbmail/dbmail-imapd.pid
+
+load_rc_config $name
+run_rc_command "$1"

--- a/contrib/startup-scripts/netbsd/dbmail_lmtpd
+++ b/contrib/startup-scripts/netbsd/dbmail_lmtpd
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# PROVIDE: dbmail_lmtpd
+# REQUIRE: DAEMON
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="dbmail_lmtpd"
+rcvar=$name
+
+command="/usr/local/sbin/dbmail-lmtpd"
+command_args=""
+pidfile=/var/run/dbmail/dbmail-lmtpd.pid
+
+load_rc_config $name
+run_rc_command "$1"

--- a/contrib/startup-scripts/netbsd/dbmail_pop3d
+++ b/contrib/startup-scripts/netbsd/dbmail_pop3d
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# PROVIDE: dbmail_pop3d
+# REQUIRE: DAEMON
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="dbmail_pop3d"
+rcvar=$name
+
+command="/usr/local/sbin/dbmail-pop3d"
+command_args=""
+pidfile=/var/run/dbmail/dbmail-pop3d.pid
+
+load_rc_config $name
+run_rc_command "$1"

--- a/contrib/startup-scripts/netbsd/dbmail_sieved
+++ b/contrib/startup-scripts/netbsd/dbmail_sieved
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# PROVIDE: dbmail_sieved
+# REQUIRE: DAEMON
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="dbmail_sieved"
+rcvar=$name
+
+command="/usr/local/sbin/dbmail-sieved"
+command_args=""
+pidfile=/var/run/dbmail/dbmail-sieved.pid
+
+load_rc_config $name
+run_rc_command "$1"

--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -38,7 +38,13 @@
 
 #define _XOPEN_SOURCE
 
-#elif !defined(__NetBSD__)
+#elif defined(__NetBSD__)
+
+/* On NetBSD, no definition of an _XOPEN_SOURCE level is needed. The
+ * features required by dbmail are enabled by default.  See the file
+ * /usr/include/sys/featuretest.h for details. */
+
+#else
 
 #define _XOPEN_SOURCE	500
 #include <features.h>

--- a/src/dbmail.h.in
+++ b/src/dbmail.h.in
@@ -38,7 +38,7 @@
 
 #define _XOPEN_SOURCE
 
-#else
+#elif !defined(__NetBSD__)
 
 #define _XOPEN_SOURCE	500
 #include <features.h>


### PR DESCRIPTION
NetBSD has a <sys/featuretest.h> that is included by everything that needs it, and that does not require any definition of _XOPEN_SOURCE to enable the features that dbmail needs.

The sample startup scripts added may be dropped into the directory /etc/rc.local.d/, and configured in /etc/rc.conf in the usual manner.