### PR TITLE
Clean up usage of 'preauth_capa' and 'capa'.

### DIFF
--- a/src/dm_imapsession.h
+++ b/src/dm_imapsession.h
@@ -83,7 +83,7 @@ typedef struct {
 ImapSession * dbmail_imap_session_new(Mempool_T);
 ImapSession * dbmail_imap_session_set_command(ImapSession * self, const char * command);
 
-void dbmail_imap_session_reset(ImapSession *session);
+void dbmail_imap_session_encrypted(ImapSession *session);
 
 void dbmail_imap_session_args_free(ImapSession *self, gboolean all);
 void dbmail_imap_session_fetch_free(ImapSession *self, gboolean all);

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -624,9 +624,9 @@ int imap_handle_connection(client_sock *c)
 	ci_cork(ci);
 
 	session->ci = ci;
+
 	if ((! server_conf->ssl) || (ci->sock->ssl_state == TRUE)) {
-		Capa_remove(session->capa, "STARTTLS");
-		Capa_remove(session->capa, "LOGINDISABLED");
+		dbmail_imap_session_encrypted(session);
 	}
 
 	fd_count = get_opened_fd_count();


### PR DESCRIPTION
The separation into the two capability maps is improved, by letting a session have exactly the capabilities, in each of them, that it's allowed to use during the pre- and post-authentication phases.  While 'capa' does not change after session initialization, 'preauth_capa' may change during the pre-authentication phase, for instance when a plaintext session successfully uses STARTTLS to enable encryption.

The initial setup of capabilities in dbmail_imap_session_new() is simplified somewhat by this change.

Capability manipulation is isolated to dm_imapsession.c, by adding a function dbmail_imap_session_encrypted(), that is called if the session successfully does a STARTTLS, or if it uses TLS to begin with.

The CAPABILITY command now returns the correct capability set for the current session state, returning either 'preauth_capa' or 'capa'.