### PR TITLE
Make support for AUTH=CRAM-MD5 configurable.

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -374,6 +374,13 @@ imap_before_smtp      = no
 # login_disabled        = yes
 
 #
+# There is support for AUTH=CRAM-MD5 in the code, but
+# the mechanism is officially deprecated, and you may
+# want to disable it, using enable_cram_md5=no here.
+#
+# enable_cram_md5       = yes
+
+#
 # Provide a CAPABILITY to override the default
 #
 # capability 		= IMAP4 IMAP4rev1 AUTH=LOGIN ACL RIGHTS=texk NAMESPACE CHILDREN SORT QUOTA THREAD=ORDEREDSUBJECT UNSELECT IDLE

--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -93,6 +93,7 @@ ImapSession * dbmail_imap_session_new(Mempool_T pool)
 	ImapSession * self;
 	Field_T val;
 	gboolean login_disabled = TRUE;
+	gboolean enable_cram_md5 = TRUE;
 
 	self = mempool_pop(pool, sizeof(ImapSession));
 
@@ -108,6 +109,10 @@ ImapSession * dbmail_imap_session_new(Mempool_T pool)
 	GETCONFIGVALUE("login_disabled", "IMAP", val);
 	if (SMATCH(val, "no"))
 		login_disabled = FALSE;
+
+	GETCONFIGVALUE("enable_cram_md5", "IMAP", val);
+	if (SMATCH(val, "no"))
+		enable_cram_md5 = FALSE;
 
 	self->state = CLIENTSTATE_NON_AUTHENTICATED;
 	self->args = mempool_pop(self->pool, sizeof(String_T) * MAX_ARGS);
@@ -141,7 +146,7 @@ ImapSession * dbmail_imap_session_new(Mempool_T pool)
 		login_disabled = FALSE;
 	}
 
-	if (MATCH(db_params.authdriver, "LDAP")) {
+	if ((! enable_cram_md5) || MATCH(db_params.authdriver, "LDAP")) {
 		Capa_remove(self->preauth_capa, "AUTH=CRAM-MD5");
 	}
 
@@ -162,6 +167,13 @@ ImapSession * dbmail_imap_session_new(Mempool_T pool)
 
 void dbmail_imap_session_encrypted(ImapSession *self)
 {
+	Field_T val;
+	gboolean enable_cram_md5 = TRUE;
+
+	GETCONFIGVALUE("enable_cram_md5", "IMAP", val);
+	if (SMATCH(val, "no"))
+		enable_cram_md5 = FALSE;
+
 	Capa_remove(self->preauth_capa, "STARTTLS");
 	Capa_remove(self->preauth_capa, "LOGINDISABLED");
 
@@ -170,7 +182,7 @@ void dbmail_imap_session_encrypted(ImapSession *self)
 	if (! Capa_match(self->preauth_capa, "AUTH=PLAIN"))
 		Capa_add(self->preauth_capa, "AUTH=PLAIN");
 
-	if (! MATCH(db_params.authdriver, "LDAP")) {
+	if (enable_cram_md5 && (! MATCH(db_params.authdriver, "LDAP"))) {
 		if (! Capa_match(self->preauth_capa, "AUTH=CRAM-MD5"))
 			Capa_add(self->preauth_capa, "AUTH=CRAM-MD5");
 	}

--- a/src/imapcommands.c
+++ b/src/imapcommands.c
@@ -299,10 +299,10 @@ int _ic_authenticate(ImapSession *self)
 {
 	if (self->command_type == IMAP_COMM_AUTH) {
 		if (!check_state_and_args(self, 1, 3, CLIENTSTATE_NON_AUTHENTICATED)) return 1;
-		/* check authentication method */
-		if ( (! MATCH(p_string_str(self->args[self->args_idx]), "login")) &&
-		     (! MATCH(p_string_str(self->args[self->args_idx]), "plain")) &&
-		     (! MATCH(p_string_str(self->args[self->args_idx]), "cram-md5")) ) {
+		/* check authentication method and announced support */
+		if ( (! (MATCH(p_string_str(self->args[self->args_idx]), "login") && Capa_match(self->preauth_capa, "AUTH=LOGIN"))) &&
+		     (! (MATCH(p_string_str(self->args[self->args_idx]), "plain") && Capa_match(self->preauth_capa, "AUTH=PLAIN"))) &&
+		     (! (MATCH(p_string_str(self->args[self->args_idx]), "cram-md5") && Capa_match(self->preauth_capa, "AUTH=CRAM-MD5"))) ) {
 			dbmail_imap_session_buff_printf(self, "%s NO Invalid authentication mechanism specified\r\n", self->tag);
 			return 1;
 		}


### PR DESCRIPTION
Since the use of CRAM-MD5 has been deprecated for quite a while, and there are clients out there that will try to use it before (or even without) falling back to PLAIN or LOGIN authentication, a parameter is added to the IMAP section of dbmail.conf.

While here, improve the checks for the requested authentication method in _ic_authenticate(), so that unsupported methods will fail early, without the server parsing (and asking for, if missing) the parameters to a method that is disabled in 'preauth_capa'.

(Note that I've chosen to fetch the configuration file value separately each time it's used. After considering options, I decided that the local presence of that code in each of the functions that want the value makes for easier comprehension of the code, compared to having a global variable, and fetching the value only in the function that is known to be called first.)