### PR TITLE
The ctype functions need unsigned char arguments, so cast as appropriate.

### DIFF
--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -419,7 +419,7 @@ static int _imap_session_fetch_parse_partspec(ImapSession *self)
 	TRACE(TRACE_DEBUG,"token [%s], nexttoken [%s]", token, nexttoken);
 
 	for (j = 0; token[j]; j++) {
-		if (isdigit(token[j])) {
+		if (isdigit((unsigned char) token[j])) {
 			indigit = 1;
 			continue;
 		} else if (token[j] == '.') {
@@ -523,7 +523,7 @@ static int _imap_session_fetch_parse_octet_range(ImapSession *self)
 				if (delimpos != -1) 
 					return -2;
 				delimpos = j;
-			} else if (!isdigit (token[j]))
+			} else if (!isdigit ((unsigned char) token[j]))
 				return -2;
 		}
 		if (delimpos == -1 || delimpos == 1 || delimpos == (int) (strlen(token) - 2))
@@ -930,7 +930,7 @@ static void _fetch_headers(ImapSession *self, body_fetch *bodyfetch, gboolean no
 
 				/* Build content as Header: value \n */
 				fld2 = g_strdup_printf("%s", fld);
-				fld2[0] = toupper(fld[0]);
+				fld2[0] = toupper((unsigned char) fld[0]);
 				new = g_strdup_printf("%s%s: %s\n", old?old:"", fld2, val);
 				g_free(val);
 				g_free(fld2);

--- a/src/dm_message.c
+++ b/src/dm_message.c
@@ -332,7 +332,7 @@ static char *find_type_header(const char *s)
 	i++;
 
 	while (rest[i]) {
-		if (((ISLF(rest[i])) || (ISCR(rest[i]))) && (!isspace(rest[i+1]))) {
+		if (((ISLF(rest[i])) || (ISCR(rest[i]))) && (!isspace((unsigned char) rest[i+1]))) {
 			break;
 		}
 		g_string_append_c(header,rest[i++]);

--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -502,7 +502,7 @@ static void _strip_blob_prefix(char *subject)
 	if (*tmp != ']')
 		return;
 
-	while (isspace(*++tmp))
+	while (isspace((unsigned char) *++tmp))
 		;
 	len = strlen(tmp);
 
@@ -687,7 +687,7 @@ int listex_match(const char *p, const char *s,
 		}
 
 		if ( (*p == *s)||
-		((flags & LISTEX_NOCASE) && (tolower(*p) == tolower(*s)))) {
+		((flags & LISTEX_NOCASE) && (tolower((unsigned char) *p) == tolower((unsigned char) *s)))) {
 			p8=(((unsigned char)*p) > 0xC0);
 			p++; s++;
 		} else {
@@ -870,7 +870,7 @@ int check_date(const char *date)
 	if (i >= 12 || days > month_len[i]) return 0;
 
 	for (i = 7; i < 11; i++)
-		if (!isdigit(date[i - j])) return 0;
+		if (!isdigit((unsigned char) date[i - j])) return 0;
 
 	return 1;
 }
@@ -884,10 +884,10 @@ int check_msg_set(const char *s)
 {
 	int i, indigit=0, result = 1;
 	
-	if (!s || (!isdigit(s[0]) && s[0]!= '*') ) return 0;
+	if (!s || (!isdigit((unsigned char) s[0]) && s[0]!= '*') ) return 0;
 
 	for (i = 0; s[i]; i++) {
-		if (isdigit(s[i]) || s[i]=='*') indigit = 1;
+		if (isdigit((unsigned char) s[i]) || s[i]=='*') indigit = 1;
 		else if (s[i] == ',') {
 			if (!indigit) {
 				result = 0;


### PR DESCRIPTION
From the Linux ctype man page:

   The standards require that the argument c for these functions is
   either EOF or a value that is representable in the type unsigned
   char. If the argument c is of type char, it must be cast to unsigned
   char, as in the following example: [...]

From the NetBSD ctype man page:

   The argument of these functions is of type int, but only a very
   restricted subset of values are actually valid.  The argument must
   either be the value of the macro EOF (which has a negative value), or
   must be a non-negative value within the range representable as
   unsigned char.  Passing invalid values leads to undefined behavior.