### PR TITLE
Use dm_base64_encode instead of g_* #496

### DIFF
--- a/src/dm_imapsession.c
+++ b/src/dm_imapsession.c
@@ -2060,7 +2060,7 @@ int imap4_tokenizer_main(ImapSession *self, const char *buffer)
 			uint64_t len;
 			char *lnul, *rnul, *tmp;
 
-			tmp = (char *) g_base64_decode(s, &len);
+			tmp = dm_base64_decode(s, &len);
 			if (! tmp) {
 				return -1;
 			}

--- a/src/dm_request.c
+++ b/src/dm_request.c
@@ -111,13 +111,13 @@ static gboolean Request_basic_auth(T R)
 	if (strncmp(auth,"Basic ", 6) == 0) {
 		Field_T userpw;
 		gsize len;
-		guchar *s;
+		gchar *s;
 		gchar *safe;
 		memset(userpw,0,sizeof(Field_T));
 		config_get_value("admin", "HTTP", userpw);
 		auth+=6;
 		TRACE(TRACE_DEBUG, "auth [%s]", auth);
-		s = g_base64_decode(auth, &len);
+		s = dm_base64_decode(auth, &len);
 		safe = g_strndup((char *)s, (gsize)len);
 		g_free(s);
 		TRACE(TRACE_DEBUG,"Authorization [%" PRIu64 "][%s] <-> [%s]", (uint64_t)len, safe, userpw);


### PR DESCRIPTION
Pull request from @KenjiBrown to fix Error compiling 3.5.5 on i686