### PR TITLE
added option for SO_REUSEPORT

### DIFF
--- a/dbmail.conf
+++ b/dbmail.conf
@@ -84,6 +84,11 @@ login_timeout         = 60
 #
 resolve_ip            = no
 
+#
+# If yes, allow multiple loadbalanced dbmail processes on the same port.
+#
+# reuseport = no
+
 ###################
 # TLS Transport Layer Security
 #

--- a/src/dbmailtypes.h
+++ b/src/dbmailtypes.h
@@ -402,6 +402,7 @@ typedef struct {
 	int service_before_smtp;
 	gboolean authlog;
 	gboolean ssl;
+	gboolean reuseport;
 	int backlog;
 	int resolveIP;
 	struct evhttp **evhs;           // http server sockets list


### PR DESCRIPTION
This PR adds a config file parameter called `reuseport` which is used in `src/server.c` to enable the socket option `SO_REUSEPORT`.
With that option enabled multiple dbmail processes can bind to the same port and the Linux kernel loadbalances incoming connections on them.
This can be useful for zero downtime upgrades/restarts and also to prevent downtime if a dbmail process is hanging.
In some scenarios this can also improve performance when the main thread handling the network I/O becomes the bottleneck but I did not benchmark that.