### PR TITLE
Fix the exit deadlock in the thread pool

### DIFF
--- a/src/dm_db.c
+++ b/src/dm_db.c
@@ -346,7 +346,7 @@ Connection_T db_con_get(void)
 		}
 		if ((unsigned int)i >= db_params.connection_pool_timeout) {
 			TRACE(TRACE_ALERT, "Connection pool stopped for [%d] sec, timed out, exiting", i);
-			exit(EX_TEMPFAIL);
+			dm_ensure_exit(EX_TEMPFAIL);
 		}
 		sleep(1);
 		i++;

--- a/src/dm_debug.c
+++ b/src/dm_debug.c
@@ -42,6 +42,35 @@ char		hostname[16];
 static Trace_T TRACE_SYSLOG = TRACE_EMERG | TRACE_ALERT | TRACE_CRIT | TRACE_ERR | TRACE_WARNING;  /* default: emerg, alert, crit, err, warning */
 static Trace_T TRACE_STDERR = TRACE_EMERG | TRACE_ALERT | TRACE_CRIT | TRACE_ERR | TRACE_WARNING;  /* default: emerg, alert, crit, err, warning */
 
+/* The thread the process started in, recorded before main() runs. */
+static GThread *main_thread = NULL;
+
+static void CONSTRUCTOR record_main_thread(void)
+{
+	main_thread = g_thread_self();
+}
+
+/*
+ * Ensure that the process exits from any thread.
+ *
+ * exit() runs the atexit handlers. One of them joins the server's
+ * thread pool, which deadlocks if exit() is called from a worker
+ * thread. Threads other than the main thread therefore use _exit(),
+ * while the main thread uses exit().
+ *
+ * Without CONSTRUCTOR support main_thread stays unset and exit() is used
+ * everywhere, i.e. the behaviour dbmail had before this change.
+ */
+void dm_ensure_exit(int status)
+{
+	if (main_thread && g_thread_self() != main_thread) {
+		fflush(NULL);
+		_exit(status);
+	}
+
+	exit(status);
+}
+
 /*
  * libzdb abort handler to handle logs correctly
  */
@@ -233,7 +262,7 @@ void trace(Trace_T level, const char * module, const char * function, int line, 
 
 	/* Bail out on fatal errors. */
 	if (level == TRACE_EMERG)
-		exit(EX_TEMPFAIL);
+		dm_ensure_exit(EX_TEMPFAIL);
 }
 
 

--- a/src/dm_debug.h
+++ b/src/dm_debug.h
@@ -49,15 +49,21 @@ typedef enum {
 #ifdef __GNUC__
 #define UNUSED __attribute__((__unused__))
 #define PRINTF_ARGS(X, Y) __attribute__((format(printf, X, Y)))
+#define CONSTRUCTOR __attribute__((constructor))
+#define NORETURN __attribute__((noreturn))
 #else
 #define UNUSED
 #define PRINTF_ARGS(X, Y)
+#define CONSTRUCTOR
+#define NORETURN
 #endif
 
 
 #define TRACE(level, fmt...) trace(level, THIS_MODULE, __func__, __LINE__, fmt)
 void TabortHandler(const char *error);
 void trace(Trace_T level, const char * module, const char * function, int line, const char *formatstring, ...) PRINTF_ARGS(5, 6);
+
+void dm_ensure_exit(int status) NORETURN;
 
 void configure_debug(const char *service_name, Trace_T trace_syslog, Trace_T trace_stderr);
 

--- a/test/check_dbmail_ensure_exit.c
+++ b/test/check_dbmail_ensure_exit.c
@@ -1,0 +1,93 @@
+#include <check.h>
+#include <sysexits.h>
+#include "dbmail.h"
+
+static GThreadPool *pool = NULL;
+
+/*
+ * atexit handler mirroring disconnect_all() in src/server.c: it waits for the
+ * jobs still running in the pool.
+ */
+static void free_pool(void)
+{
+	if (pool) {
+		g_thread_pool_free(pool, TRUE, TRUE);
+		pool = NULL;
+	}
+}
+
+/* Pool job: ends the process from a worker thread. */
+static void exit_job(gpointer data, gpointer user_data)
+{
+	(void)data;
+	(void)user_data;
+	dm_ensure_exit(EX_TEMPFAIL);
+}
+
+/* Exits at once, so reaching the atexit chain is observable as EX_OK. */
+static void atexit_marker(void)
+{
+	_exit(EX_OK);
+}
+
+/*
+ * Verify that a worker thread can end the process while an atexit handler
+ * joins the pool that worker runs in. Calling exit() there deadlocks: the join
+ * waits for the calling job to finish, so the test times out instead of
+ * exiting, and every other thread blocks on the exit handlers.
+ *
+ * Requires CK_FORK=yes (the default) because the test exits the process.
+ */
+START_TEST(test_dm_ensure_exit_from_pool_worker)
+{
+	ck_assert_int_eq(atexit(free_pool), 0);
+
+	pool = g_thread_pool_new(exit_job, NULL, 1, FALSE, NULL);
+	ck_assert_ptr_ne(pool, NULL);
+	ck_assert_int_eq(g_thread_pool_push(pool, GINT_TO_POINTER(1), NULL), TRUE);
+
+	/* The job ends the process; if it does not, the tcase timeout fails
+	 * the test.
+	 */
+	pause();
+}
+END_TEST
+
+/*
+ * Verify that the main thread still runs the atexit handlers, so the ordinary
+ * shutdown keeps working. Skipping them there would leave the process with
+ * EX_TEMPFAIL instead.
+ */
+START_TEST(test_dm_ensure_exit_runs_atexit_on_main_thread)
+{
+	ck_assert_int_eq(atexit(atexit_marker), 0);
+
+	dm_ensure_exit(EX_TEMPFAIL);
+}
+END_TEST
+
+Suite *dbmail_ensure_exit_suite(void)
+{
+	Suite *s = suite_create("Dbmail Ensure Exit");
+	TCase *tc = tcase_create("EnsureExit");
+
+	suite_add_tcase(s, tc);
+
+	tcase_set_timeout(tc, 10);
+	tcase_add_exit_test(tc, test_dm_ensure_exit_from_pool_worker, EX_TEMPFAIL);
+	tcase_add_exit_test(tc, test_dm_ensure_exit_runs_atexit_on_main_thread, EX_OK);
+
+	return s;
+}
+
+int main(void)
+{
+	int nf;
+	Suite *s = dbmail_ensure_exit_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_ENV);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
### Problem

When the database stays unavailable for longer than
`connection_pool_timeout`, dbmail logs that it is exiting — and then
never exits. The listening socket stays open, new IMAP logins hang, and
because the process never terminates, systemd sees no failure and
`Restart=on-failure` never fires.

The log shows the decision to exit, and then nothing:

```
db_con_get: Connection pool stopped for [16] sec, timed out, exiting
disconnect_all: disconnecting all
```

### Root cause

`db_con_get()` calls `exit(EX_TEMPFAIL)` when the timeout expires. If
that happens in a thread-pool job, the process deadlocks inside
`exit()`.

`exit()` runs `server_exit()`, registered with `atexit()` in
`src/server.c`, which calls `disconnect_all()`.
`disconnect_all()` calls `g_thread_pool_free(tpool, TRUE, TRUE)`, where
`wait_ = TRUE` waits for every running job to finish. Since the caller is
one of those jobs, it waits for itself and never returns.

The thread holds glibc's exit-handler lock, so every later call to
`exit()` blocks as well, including the main thread. As a result, the
libevent loop stops dispatching while the listening socket remains open.

Backtrace from a reproduced hang:

```text
Thread 5 "pool":                      <- self-join; holds the exit lock
#1  g_cond_wait ()
#2  g_thread_pool_free ()
#3  disconnect_all ()
#4  server_exit ()
#5  __run_exit_handlers ()
#6  exit ()
#7  db_con_get ()

Thread 3 "pool":                      <- blocked on the lock Thread 5 holds
#0  __lll_lock_wait_private ()
#1  __run_exit_handlers ()
#3  db_con_get ()

Thread 1 "dbmail-imapd":              <- main thread, same lock, event loop dead
#0  __lll_lock_wait_private ()
#1  __run_exit_handlers ()
#3  db_con_get ()
#4  dm_db_ping ()
#5  imap4 ()
#10 event_base_loop ()
```

`TRACE_EMERG` in `trace()` has the same problem. It also ends in
`exit(EX_TEMPFAIL)`, so calling it from a thread-pool job deadlocks in
the same way. `dm_iconv.c`, for example, raises `TRACE_EMERG` while
parsing a message.

### Fix

Add `dm_ensure_exit()`, which ends the process without the `atexit`
handlers when called from a thread other than the main thread:

```c
static GThread *main_thread = NULL;

static void CONSTRUCTOR record_main_thread(void)
{
        main_thread = g_thread_self();
}

void dm_ensure_exit(int status)
{
        if (main_thread && g_thread_self() != main_thread) {
                fflush(NULL);
                _exit(status);
        }

        exit(status);
}
```

and use it at the two sites that can run in a job: the timeout in
`db_con_get()` and `TRACE_EMERG` in `trace()`.

Skipping the handlers is deliberate because releasing the connection
pool while other threads are still using it is unsafe. The stale pidfile
left behind is harmless because `pidfile_pid()` checks `kill(pid, 0)` at
startup and removes it if the process no longer exists. `fflush(NULL)` is
needed because `_exit()` does not flush stdio.

Calls from the main thread still run the handlers, so the normal
shutdown path is unchanged.

`CONSTRUCTOR` and `NORETURN` are added next to the existing `UNUSED` and
`PRINTF_ARGS` macros in `dm_debug.h`. Without `CONSTRUCTOR`,
`main_thread` would never be initialized and `dm_ensure_exit()` would
always fall back to `exit()`, preserving today's behaviour.

### Testing

Added `check_dbmail_ensure_exit`.

The first case reproduces the deadlock from a thread-pool job without
depending on `server.c` internals. The second verifies that calls from
the main thread still run the normal exit handlers.
