### PR TITLE
Fix use-after-free of connections at shutdown

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -722,15 +722,17 @@ void disconnect_all(void)
 {
 	TRACE(TRACE_INFO, "disconnecting all");
 
+	/* Wait for the running jobs before releasing anything they use. */
+	if (tpool) {
+		g_thread_pool_free(tpool, TRUE, TRUE);
+		tpool = NULL;
+	}
+
 	db_disconnect();
 	auth_disconnect();
 	g_mime_shutdown();
 	config_free();
 
-	if (tpool) {
-		g_thread_pool_free(tpool, TRUE, TRUE);
-		tpool = NULL;
-	}
 	if (sig_int) {
 		event_free(sig_int);
 		sig_int = NULL;

--- a/test/check_dbmail_disconnect_all.c
+++ b/test/check_dbmail_disconnect_all.c
@@ -1,0 +1,101 @@
+#include <check.h>
+#include <sysexits.h>
+#include "dbmail.h"
+
+extern char configFile[PATH_MAX];
+
+/*
+ * tpool and disconnect_all() are non-static globals in src/server.c; they are
+ * simply not declared in server.h.
+ */
+extern GThreadPool *tpool;
+extern void disconnect_all(void);
+
+/* Number of queries the job runs while holding its connection. */
+#define JOB_QUERIES 10
+
+static volatile int holding = 0;
+
+void setup(void)
+{
+	config_get_file();
+	config_read(configFile);
+	configure_debug(NULL, 0, 0);
+	GetDBParams();
+	db_connect();
+}
+
+void teardown(void)
+{
+}
+
+/*
+ * Pool job: takes a connection and keeps using it, the way an IMAP command
+ * holds one for the whole duration of a query.
+ */
+static void job(gpointer data, gpointer user_data)
+{
+	Connection_T c;
+	int i;
+
+	(void)data;
+	(void)user_data;
+
+	c = db_con_get();
+	holding = 1;
+
+	for (i = 0; i < JOB_QUERIES; i++) {
+		usleep(100000);
+		db_query(c, "SELECT %d", i);
+	}
+
+	db_con_close(c);
+}
+
+/*
+ * Verify that disconnect_all() waits for the running pool jobs before it
+ * releases what those jobs are using.
+ *
+ * The job holds a connection for about a second. If disconnect_all() calls
+ * db_disconnect() first, the connection pool is freed underneath the job and
+ * it dies in libzdb with SIGSEGV, failing this test.
+ */
+START_TEST(test_disconnect_all_waits_for_pool_jobs)
+{
+	tpool = g_thread_pool_new(job, NULL, 1, FALSE, NULL);
+	ck_assert_ptr_ne(tpool, NULL);
+	ck_assert_int_eq(g_thread_pool_push(tpool, GINT_TO_POINTER(1), NULL), TRUE);
+
+	while (! holding)
+		usleep(10000);
+	usleep(300000);		/* let the job get into its query loop */
+
+	disconnect_all();
+}
+END_TEST
+
+Suite *dbmail_disconnect_all_suite(void)
+{
+	Suite *s = suite_create("Dbmail Disconnect All");
+	TCase *tc = tcase_create("DisconnectAll");
+
+	suite_add_tcase(s, tc);
+
+	tcase_add_checked_fixture(tc, setup, teardown);
+	tcase_set_timeout(tc, 20);
+	tcase_add_test(tc, test_disconnect_all_waits_for_pool_jobs);
+
+	return s;
+}
+
+int main(void)
+{
+	int nf;
+	Suite *s = dbmail_disconnect_all_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_ENV);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
> **Depends on #546 — please merge that one first.** It stops `exit()` being
> called on a thread-pool thread. Until it is in, making the join the first step
> of `disconnect_all()` turns today's intermittent hang into a certain one.
>
> This branch is cut from `main`, not from #546, so it applies cleanly either
> way — but the order matters. Left as a draft until #546 lands. Happy to wait
> or rebase.

### Background

This picks up a question from #460:

> I'm not sure why you have moved the block in disconnect_all() that disconnects
> and shutdowns etc after the g_thread_pool_free. Unless I'm missing something it
> makes sense to disconnect etc before freeing the pool.

A fair question, and I sent that reordering without explaining it. Here is the
answer, with a reproduction.

The short version: two different pools are involved. `g_thread_pool_free(tpool,
…)` does not free a connection pool — it waits for the worker **threads**. The
connection pool is freed by `db_disconnect()`. So "disconnect before freeing the
pool" means releasing the connections while the workers that use them are still
running.

### Problem

dbmail can segfault during shutdown while requests are still being served. The
process dies inside libzdb, executing a query on a connection that no longer
exists.

### Root cause

`disconnect_all()` releases the database connections before waiting for the
thread pool. A worker may hold a `Connection_T` returned by `db_con_get()`
while `db_disconnect()` closes and frees it.

This also violates libzdb's documented shutdown order:

> `ConnectionPool_stop()` — Gracefully terminates the pool.
>
> **This method should be the last one called on a given instance of this
> component.** Calling this method closes down all connections in the pool,
> disconnects the pool from the database server, and stops the reaper thread if
> it was started.

### Fix

Wait for the worker threads first, then release the resources they use:

```c
        TRACE(TRACE_INFO, "disconnecting all");

        /* Wait for the running jobs before releasing anything they use. */
        if (tpool) {
                g_thread_pool_free(tpool, TRUE, TRUE);
                tpool = NULL;
        }

        db_disconnect();
        auth_disconnect();
        g_mime_shutdown();
        config_free();
```

Once `g_thread_pool_free()` returns, no worker thread is still running, so
nothing can access those resources afterwards.

Shutdown now waits for the longest running job. With an unreachable database,
that can take up to `connection_pool_timeout`.

### Testing

Added `check_dbmail_disconnect_all`. It reproduces the crash by keeping a
database connection in use while the main thread calls `disconnect_all()`.

Without this change:

```text
0%: Checks: 1, Failures: 0, Errors: 1
check_dbmail_disconnect_all.c:67:E:DisconnectAll:test_disconnect_all_waits_for_pool_jobs:0: (after this point) Received signal 11 (Segmentation fault)
```

Where it dies:

```text
Thread 3 "pool" received signal SIGSEGV:
#0  0x000000001026a35b in ??? ()
#1  Connection_executeQuery () at /lib64/libzdb.so.18
#2  db_query (c=0x101185f0, …) at dm_db.c:459
#3  job ()
#4  g_thread_pool_thread_proxy ()

Thread 1 (main):
#0  syscall ()
#1  g_cond_wait ()
#2  g_thread_pool_free ()
#3  main ()
```

The worker is executing a query on a freed connection while the main thread is
only starting to wait for it.
