### PR TITLE
Log the event loop failure and exit non-zero

### DIFF
--- a/src/dm_misc.c
+++ b/src/dm_misc.c
@@ -162,6 +162,21 @@ int get_opened_fd_count(void)
 	#endif
 }
 
+int check_fd_headroom(int threshold, int *fd_count, unsigned long *fd_limit)
+{
+	struct rlimit rl;
+
+	*fd_count = get_opened_fd_count();
+	if (*fd_count < 0 || getrlimit(RLIMIT_NOFILE, &rl) < 0)
+		return -1;
+
+	*fd_limit = (unsigned long) rl.rlim_cur;
+	if (rl.rlim_cur < (rlim_t) *fd_count + threshold)
+		return 0;
+
+	return 1;
+}
+
 void create_unique_id(char *target, uint64_t message_idnr)
 {
 	char md5_str[FIELDSIZE];

--- a/src/dm_misc.h
+++ b/src/dm_misc.h
@@ -55,6 +55,19 @@ int drop_privileges(char *newuser, char *newgroup);
 int get_opened_fd_count(void);
 
 /**
+   \brief check that at least threshold file descriptors stay free
+          below the RLIMIT_NOFILE soft limit
+   \param threshold minimal number of free descriptors required
+   \param fd_count set to the current number of opened files
+   \param fd_limit set to the RLIMIT_NOFILE soft limit
+   \return
+        - -1 on error
+        -  0 when fewer than threshold descriptors are free
+        -  1 when at least threshold descriptors are free
+*/
+int check_fd_headroom(int threshold, int *fd_count, unsigned long *fd_limit);
+
+/**
  * \brief create a unique id for a message (used for pop, stored per message)
  * \param target target string. Length should be UID_SIZE 
  * \param message_idnr message_idnr of message

--- a/src/imap4.c
+++ b/src/imap4.c
@@ -609,7 +609,7 @@ int imap_handle_connection(client_sock *c)
 {
 	ImapSession *session;
 	ClientBase_T *ci;
-	struct rlimit fd_limit;
+	unsigned long fd_limit;
 	int fd_count;
 
 	ci = client_init(c);
@@ -629,18 +629,20 @@ int imap_handle_connection(client_sock *c)
 		dbmail_imap_session_encrypted(session);
 	}
 
-	fd_count = get_opened_fd_count();
-	if (fd_count < 0 || getrlimit(RLIMIT_NPROC, &fd_limit) < 0) {
+	switch (check_fd_headroom(FREE_DF_THRESHOLD, &fd_count, &fd_limit)) {
+	case -1:
 		TRACE(TRACE_ERR,
 			"[%p] failed to retrieve fd limits, dropping client connection",
 			session);
 		disconnect_user(session);
-	} else if (fd_limit.rlim_cur - fd_count < FREE_DF_THRESHOLD) {
+		break;
+	case 0:
 		TRACE(TRACE_WARNING,
-			"[%p] fd count [%d], fd limit [%ld], fd threshold [%d]: dropping client connection",
-			session, fd_count, fd_limit.rlim_cur, FREE_DF_THRESHOLD);
+			"[%p] fd count [%d], fd limit [%lu], fd threshold [%d]: dropping client connection",
+			session, fd_count, fd_limit, FREE_DF_THRESHOLD);
 		disconnect_user(session);
-	} else {
+		break;
+	default:
 		send_greeting(session);
 	}
 

--- a/src/server.c
+++ b/src/server.c
@@ -264,15 +264,66 @@ static int server_setup(ServerConfig_T *conf)
 	return 0;
 }
 
-#ifdef DEBUG
-static void _cb_log_event(int UNUSED severity, const char *msg)
+static void _cb_log_event(int severity, const char *msg)
 {
-	TRACE(TRACE_WARNING, "%s", msg);
+	Trace_T trace_level;
+
+	switch (severity) {
+	case EVENT_LOG_DEBUG:
+		trace_level = TRACE_DEBUG;
+		break;
+	case EVENT_LOG_MSG:
+		trace_level = TRACE_INFO;
+		break;
+	case EVENT_LOG_WARN:
+		trace_level = TRACE_WARNING;
+		break;
+	default:
+		trace_level = TRACE_ERR;
+		break;
+	}
+
+	TRACE(trace_level, "%s", msg);
 }
+
+static void server_event_init(void)
+{
+	evthread_use_pthreads();
+	/* Route libevent diagnostics into our own log. Without this they go to
+	 * stderr, so the reason the event loop exited never shows up next to
+	 * the rest of the trace. */
+	event_set_log_callback(_cb_log_event);
+#ifdef DEBUG
+	event_enable_debug_mode();
 #endif
+	evbase = event_base_new();
+}
+
+static int server_dispatch(void)
+{
+	int result;
+
+	TRACE(TRACE_DEBUG, "dispatching event loop...");
+
+	result = event_base_dispatch(evbase);
+
+	/* A normal shutdown never gets here: server_sig_cb() exits from the
+	 * signal callback and nothing calls event_base_loopexit(), so zero
+	 * can only mean a deliberate stop added in the future - keep it
+	 * clean. Anything else means the loop failed. */
+	if (result == 0)
+		return 0;
+
+	TRACE(TRACE_ALERT, "event loop terminated unexpectedly: %s",
+		result < 0 ? "backend error" : "no more pending events");
+
+	return -1;
+}
 
 static int server_start_cli(ServerConfig_T *conf)
 {
+	int result = 0;
+
 	server_conf = conf;
 	if (db_connect() != 0) {
 		TRACE(TRACE_ERR, "could not connect to database");
@@ -296,37 +347,32 @@ static int server_start_cli(ServerConfig_T *conf)
 		Mempool_T pool = mempool_open();
 		client_sock *c = mempool_pop(pool, sizeof(client_sock));
 		c->pool = pool;
-		evthread_use_pthreads();
-#ifdef DEBUG
-		event_enable_debug_mode();
-		event_set_log_callback(_cb_log_event);
-#endif
-
-		evbase = event_base_new();
+		server_event_init();
 		if (server_setup(conf)) return -1;
 		conf->ClientHandler(c);
 
 		if (MATCH(conf->service_name, "IMAP"))
 			dm_queue_heartbeat();
 
-		event_base_dispatch(evbase);
+		result = server_dispatch();
 	}
 
 	disconnect_all();
 
-	TRACE(TRACE_INFO, "connections closed"); 
-	return 0;
+	TRACE(TRACE_INFO, "connections closed");
+	return result;
 }
 
 // PUBLIC
 int StartCliServer(ServerConfig_T * conf)
 {
+	int result;
 	assert(conf);
-	server_start_cli(conf);
+	result = server_start_cli(conf);
 #ifdef HAVE_SYSTEMD
 	sd_notify(0, "STOPPING=1");
 #endif
-	return 0;
+	return result;
 }
 
 /* Should be called after a HUP to allow for log rotation,
@@ -804,12 +850,7 @@ int server_run(ServerConfig_T *conf)
 
 	server_conf = conf;
 
-	evthread_use_pthreads();
-#ifdef DEBUG
-	event_enable_debug_mode();
-	event_set_log_callback(_cb_log_event);
-#endif
-	evbase = event_base_new();
+	server_event_init();
 
 	if (server_setup(conf))
 		return -1;
@@ -873,11 +914,7 @@ int server_run(ServerConfig_T *conf)
 #ifdef HAVE_SYSTEMD
 	sd_notify(0, "READY=1");
 #endif
-	TRACE(TRACE_DEBUG,"dispatching event loop...");
-
-	event_base_dispatch(evbase);
-
-	return 0;
+	return server_dispatch();
 }
 
 void server_showhelp(const char *name, const char *greeting) {
@@ -999,6 +1036,8 @@ int server_getopt(ServerConfig_T *config, const char *service, int argc, char *a
 
 int server_mainloop(ServerConfig_T *config, const char *servicename)
 {
+	int result;
+
 	strncpy(config->process_name, servicename, FIELDSIZE-1);
 
 	g_mime_init();
@@ -1012,20 +1051,20 @@ int server_mainloop(ServerConfig_T *config, const char *servicename)
 	tls_context = tls_init();
 
 	if (config->no_daemonize == 1) {
-		StartCliServer(config);
+		result = StartCliServer(config);
 		TRACE(TRACE_INFO, "exiting cli server");
-		return 0;
+		return result;
 	}
-	
+
 	if (! config->no_daemonize)
 		server_daemonize(config);
 
 	/* This is the actual main loop. */
-	server_run(config);
+	result = server_run(config);
 
 	server_config_free(config);
-	TRACE(TRACE_INFO, "leaving main loop");
-	return 0;
+	TRACE(TRACE_INFO, "leaving main loop with [%d]", result);
+	return result;
 }
 
 

--- a/test/check_dbmail_fd_headroom.c
+++ b/test/check_dbmail_fd_headroom.c
@@ -1,0 +1,64 @@
+#include <check.h>
+#include <sys/resource.h>
+#include "check_dbmail.h"
+
+/*
+ * check_fd_headroom() implements the guard that refuses a new client
+ * connection when the process is about to run out of file descriptors.
+ * The soft RLIMIT_NOFILE limit can be lowered without privileges, so
+ * the test drives the guard through its live states with setrlimit().
+ */
+
+START_TEST(test_check_fd_headroom)
+{
+	struct rlimit orig, rl;
+	int fd_count = 0;
+	unsigned long fd_limit = 0;
+
+	ck_assert_int_eq(getrlimit(RLIMIT_NOFILE, &orig), 0);
+
+	/* the real limit leaves plenty of headroom */
+	ck_assert_int_eq(check_fd_headroom(FREE_DF_THRESHOLD, &fd_count, &fd_limit), 1);
+	ck_assert_int_gt(fd_count, 0);
+	ck_assert_uint_eq(fd_limit, (unsigned long) orig.rlim_cur);
+
+	/* one descriptor short of the threshold: the guard must fire */
+	rl = orig;
+	rl.rlim_cur = fd_count + FREE_DF_THRESHOLD - 1;
+	ck_assert_int_eq(setrlimit(RLIMIT_NOFILE, &rl), 0);
+	ck_assert_int_eq(check_fd_headroom(FREE_DF_THRESHOLD, &fd_count, &fd_limit), 0);
+	ck_assert_uint_eq(fd_limit, (unsigned long) rl.rlim_cur);
+
+	/* exactly the threshold free: still enough */
+	rl.rlim_cur = fd_count + FREE_DF_THRESHOLD;
+	ck_assert_int_eq(setrlimit(RLIMIT_NOFILE, &rl), 0);
+	ck_assert_int_eq(check_fd_headroom(FREE_DF_THRESHOLD, &fd_count, &fd_limit), 1);
+
+	ck_assert_int_eq(setrlimit(RLIMIT_NOFILE, &orig), 0);
+}
+END_TEST
+
+Suite *dbmail_fd_headroom_suite(void)
+{
+	Suite *s = suite_create("Dbmail FdHeadroom");
+	TCase *tc = tcase_create("FdHeadroom");
+
+	suite_add_tcase(s, tc);
+
+	tcase_set_timeout(tc, 10);
+	tcase_add_test(tc, test_check_fd_headroom);
+
+	return s;
+}
+
+int main(void)
+{
+	int nf;
+	Suite *s = dbmail_fd_headroom_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_ENV);
+	nf = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (nf == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
### Problem

When the event loop fails, dbmail-imapd exits with status 0. systemd's Restart=on-failure therefore never restarts it, and the log does not say why the loop ended. This is what made the silent exits fixed in #553 hard to diagnose.

### Root cause

The libevent log callback is registered only under #ifdef DEBUG, which release builds do not define, so libevent diagnostics go to stderr. server_run(), server_start_cli() and server_mainloop() discard the event_base_dispatch() result.

### Fix

The first commit registers the log callback unconditionally and maps libevent severities to the daemon trace levels. An unexpected dispatcher return is logged and propagated as a non-zero exit status, so systemd restarts the daemon.

The second commit fixes the free descriptor guard in imap_handle_connection(). It compared the descriptor count against RLIMIT_NPROC, which counts processes, so it never fired. The check now queries RLIMIT_NOFILE and lives in check_fd_headroom() in dm_misc.c.

### Testing

test/check_dbmail_fd_headroom.c drives the guard through its states with setrlimit().
