### PR TITLE
Make the fd count assertion portable

### DIFF
--- a/test/check_dbmail_fd_headroom.c
+++ b/test/check_dbmail_fd_headroom.c
@@ -19,7 +19,12 @@ START_TEST(test_check_fd_headroom)
 
 	/* the real limit leaves plenty of headroom */
 	ck_assert_int_eq(check_fd_headroom(FREE_DF_THRESHOLD, &fd_count, &fd_limit), 1);
+	/* get_opened_fd_count() is a stub returning 0 on these platforms */
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__SUNPRO_C)
+	ck_assert_int_eq(fd_count, 0);
+#else
 	ck_assert_int_gt(fd_count, 0);
+#endif
 	ck_assert_uint_eq(fd_limit, (unsigned long) orig.rlim_cur);
 
 	/* one descriptor short of the threshold: the guard must fire */


### PR DESCRIPTION
`get_opened_fd_count()` is a stub returning 0 on FreeBSD, macOS and Solaris, so the `fd_count > 0` assertion from #554 fails there, as noted in https://github.com/dbmail/dbmail/pull/554#discussion_r3814759739. Expect 0 on those platforms and keep `> 0` elsewhere. Tested on Linux.