### PR TITLE
imapd: lost wakeup in cb_queue_drain() can wedge sessions indefinitely

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -81,12 +81,13 @@ pthread_mutex_t selfpipe_lock;
 static void cb_queue_drain(int fd, short what UNUSED, void *arg UNUSED)
 {
 	char buf[1024];
-	event_del(heartbeat);
-	dm_queue_drain();
+	ssize_t r;
 	PLOCK(selfpipe_lock);
-	if (read(fd, buf, sizeof(buf))) { /* ignore */ }
+	do {
+		r = read(fd, buf, sizeof(buf));
+	} while (r == sizeof(buf));
 	PUNLOCK(selfpipe_lock);
-	event_add(heartbeat, NULL);
+	dm_queue_drain();
 }
 
 
@@ -100,7 +101,7 @@ void dm_queue_heartbeat(void)
 
 	pthread_mutex_init(&selfpipe_lock, NULL);
 
-	heartbeat = event_new(evbase, selfpipe[0], EV_READ, cb_queue_drain, NULL);
+	heartbeat = event_new(evbase, selfpipe[0], EV_READ|EV_PERSIST, cb_queue_drain, NULL);
 	event_add(heartbeat, NULL);
 }
 


### PR DESCRIPTION
`cb_queue_drain()` drains the async queue *before* reading the self-pipe, while
workers push their job *before* writing the notification byte. If a worker's
push lands after the drain but its byte before the read, the byte is consumed
and the job is stranded with no event pending.

It then hangs until traffic on some other connection happens to drain the queue.
Busy servers mask this; idle ones wedge visibly. The window is hit easily because
each command pushes twice in quick succession (`buff_flush` + `SESSION_RETURN`),
so the main thread is often mid-drain when the second push arrives.

Having a slow CPU might be a prerequisite to trigger this reliably.
Easy to reproduce on NetBSD and probably on other platforms by inserting
`usleep(2000);` between the drain and the read.

Fix: read the pipe before draining. A job missed by the drain must then have
written its byte after our read, so the byte survives and the event re-fires.
Also makes the heartbeat persistent and drains the pipe fully (a full
non-blocking pipe drops wakeup writes).
